### PR TITLE
Raise limit of ScriptSig size in IsStandard check.

### DIFF
--- a/NBitcoin/StandardScripts.cs
+++ b/NBitcoin/StandardScripts.cs
@@ -73,10 +73,14 @@ namespace NBitcoin
 
 			foreach(TxIn txin in tx.Inputs)
 			{
-				// Biggest 'standard' txin is a 3-signature 3-of-3 CHECKMULTISIG
-				// pay-to-script-hash, which is 3 ~80-byte signatures, 3
-				// ~65-byte public keys, plus a few script ops.
-				if(txin.ScriptSig.Length > 500)
+				// Biggest 'standard' txin is a 15-of-15 P2SH multisig with compressed
+				// keys. (remember the 520 byte limit on redeemScript size) That works
+				// out to a (15*(33+1))+3=513 byte redeemScript, 513+1+15*(73+1)+3=1627
+				// bytes of scriptSig, which we round off to 1650 bytes for some minor
+				// future-proofing. That's also enough to spend a 20-of-20
+				// CHECKMULTISIG scriptPubKey, though such a scriptPubKey is not
+				// considered standard)
+				if (txin.ScriptSig.Length > 1650)
 				{
 					return false;
 				}

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -537,7 +537,7 @@ namespace NBitcoin
 				if(value == null)
 					throw new ArgumentNullException("value");
 				if(value.Satoshi > long.MaxValue || value.Satoshi < long.MinValue)
-					throw new ArgumentOutOfRangeException("satoshi's value should be between Int64.Max and Int64.Min");
+					throw new ArgumentOutOfRangeException("value","satoshi's value should be between Int64.Max and Int64.Min");
 				_MoneyValue = value;
 				this.value = (long)_MoneyValue.Satoshi;
 			}


### PR DESCRIPTION
Change synchronize NBitcoin with raised limit as of Bitcoin Core v0.10

