### PR TITLE
Change default maximum OP_RETURN size to 80 bytes

### DIFF
--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -1347,12 +1347,12 @@ namespace NBitcoin.Tests
 			t.Outputs[0].ScriptPubKey = new Script() + OpcodeType.OP_1;
 			Assert.True(!StandardScripts.IsStandardTransaction(t));
 
-			// 40-byte TX_NULL_DATA (standard)
-			t.Outputs[0].ScriptPubKey = new Script() + OpcodeType.OP_RETURN + ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
+			// 80-byte TX_NULL_DATA (standard)
+            t.Outputs[0].ScriptPubKey = new Script() + OpcodeType.OP_RETURN + ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
 			Assert.True(StandardScripts.IsStandardTransaction(t));
 
-			// 41-byte TX_NULL_DATA (non-standard)
-			t.Outputs[0].ScriptPubKey = new Script() + OpcodeType.OP_RETURN + ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800");
+			// 81-byte TX_NULL_DATA (non-standard)
+            t.Outputs[0].ScriptPubKey = new Script() + OpcodeType.OP_RETURN + ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800");
 			Assert.True(!StandardScripts.IsStandardTransaction(t));
 
 			// TX_NULL_DATA w/o PUSHDATA

--- a/NBitcoin/StandardScriptTemplate.cs
+++ b/NBitcoin/StandardScriptTemplate.cs
@@ -66,7 +66,7 @@ namespace NBitcoin
 			return false;
 		}
 
-		public const int MAX_OPRETURN_SIZE = 40;
+		public const int MAX_OPRETURN_SIZE = 80;
 		public Script GenerateScriptPubKey(byte[] data)
 		{
 			if(data == null)


### PR DESCRIPTION
... to maintain compatibility with Bitcoin Core v0.10. See: https://github.com/bitcoin/bitcoin/pull/5286/files