### PR TITLE
overflow checks for money

### DIFF
--- a/NBitcoin.Tests/script_tests.cs
+++ b/NBitcoin.Tests/script_tests.cs
@@ -44,8 +44,8 @@ namespace NBitcoin.Tests
 			{
 				if(w == "")
 					continue;
-				if(w.All(l => Money.isdigit(l)) ||
-					(w.StartsWith("-") && w.Substring(1).All(l => Money.isdigit(l))))
+				if(w.All(l => l.IsDigit()) ||
+					(w.StartsWith("-") && w.Substring(1).All(l => l.IsDigit())))
 				{
 
 					// Number


### PR DESCRIPTION
@NicolasDorier this PR fixes the bugs discussed in my previous PR #80:

## Fixes

* Checks for overflow in all ctors where an overflow could occurs. The following throws OverflowException now:
```
	[Fact]
	public void Overflow()
	{
		var money = new Money(9223372036854775808uL);
	}
```
* Validates MoneyUnit values passed in parameters. The following is no allowed any more:
```
    var unitToUseStr = Request["unitSelectedByUser"];  // "47"
    var unit = int.Parse(unitToUseStr); // 47
    var money = new Money(1, (MoneyUnit)unit);
```
* Oparations involving doubles and ulong are safe now 
* Operator --(Money left) checks overflows but it still modifies the internal state, making the Money class mutable. The only difference is that with this PR the internal state remains valid.

Also, I have changed the Money.ToString() method's internal implementation. It returns exactly the same strings as before but it is clearer.

There are two new UTs for the Money class (more are required).

## Things that still smell bad

* **operator /()** is error prone and a good way to lose money.
```
    [Fact]
    public void IntegerDivision()
    {
        var total = new Money(1.0m, MoneyUnit.BTC);
        var op = (total/300000) * 300000;
        Assert.Equal(total.Satoshi, op.Satoshi, "we've lost money bro!");
    }
```
>Test 'NBitcoin.Tests.util_tests.IntegerDivision' failed: Assert.Equal() Failure
>Expected: 100000000
>Actual:   99900000   

* **operator --()** and **operator ++()** change the internal state and Money should be inmutable.

Some operators make no sense because they are okay for integers but no for money.
For example, this could be okay: 
```
     money.AddSatoshis(1)
```
but, what does this mean?:  
```
     money++
```

++ and -- make sense for integers but doesn't make any sense for money.