### PR TITLE
Minor cleanup & Fix code 

### DIFF
--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -2,9 +2,13 @@
 using NBitcoin.BouncyCastle.Crypto.Digests;
 using System.IO;
 using System.Linq;
+using NBitcoin.BouncyCastle.Crypto.Parameters;
+using NBitcoin.BouncyCastle.Security;
 #if !USEBC
 using System.Security.Cryptography;
+
 #endif
+
 
 namespace NBitcoin.Crypto
 {

--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -1,13 +1,7 @@
-﻿using NBitcoin.BouncyCastle.Crypto.Digests;
-using NBitcoin.BouncyCastle.Crypto.Parameters;
-using NBitcoin.BouncyCastle.Security;
-using System;
-using System.Collections.Generic;
+﻿using System;
+using NBitcoin.BouncyCastle.Crypto.Digests;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 #if !USEBC
 using System.Security.Cryptography;
 #endif
@@ -16,18 +10,18 @@ namespace NBitcoin.Crypto
 {
 	public class Hashes
 	{
-		public static uint256 Hash256(byte[] data, int count)
+		public static uint256 Hash256(byte[] data, int offset, int count)
 		{
 			data = count == 0 ? new byte[1] : data;
 #if !USEBC
 			using(var sha = System.Security.Cryptography.SHA256.Create())
 			{
-				var h = sha.ComputeHash(data, 0, count);
+				var h = sha.ComputeHash(data, offset, count);
 				return new uint256(sha.ComputeHash(h, 0, h.Length));
 			}
 #else
 			Sha256Digest sha256 = new Sha256Digest();
-			sha256.BlockUpdate(data, 0, count);
+			sha256.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[32];
 			sha256.DoFinal(rv, 0);
 			sha256.BlockUpdate(rv, 0, rv.Length);
@@ -39,23 +33,23 @@ namespace NBitcoin.Crypto
 
 		public static uint256 Hash256(byte[] data)
 		{
-			return Hash256(data, data.Length);
+			return Hash256(data, 0, data.Length);
 		}
 
-		public static uint160 Hash160(byte[] data, int count)
+		public static uint160 Hash160(byte[] data, int offset, int count)
 		{
-			data = count == 0 ? new byte[1] : data;
-			return new uint160(RIPEMD160(SHA256(data, count)));
+			//data = count == 0 ? new byte[1] : data;
+			return new uint160(RIPEMD160(SHA256(data, offset, count)));
 		}
 
 		private static byte[] RIPEMD160(byte[] data)
 		{
-			return RIPEMD160(data, data.Length);
+			return RIPEMD160(data, 0, data.Length);
 		}
-		public static byte[] SHA1(byte[] data, int count)
+		public static byte[] SHA1(byte[] data, int offset, int count)
 		{
 			var sha1 = new Sha1Digest();
-			sha1.BlockUpdate(data, 0, count);
+			sha1.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[20];
 			sha1.DoFinal(rv, 0);
 			return rv;
@@ -63,18 +57,18 @@ namespace NBitcoin.Crypto
 
 		public static byte[] SHA256(byte[] data)
 		{
-			return SHA256(data, data.Length);
+			return SHA256(data, 0, data.Length);
 		}
-		public static byte[] SHA256(byte[] data, int count)
+		public static byte[] SHA256(byte[] data, int offset, int count)
 		{
 #if !USEBC
 			using(var sha = System.Security.Cryptography.SHA256.Create())
 			{
-				return sha.ComputeHash(data, 0, count);
+				return sha.ComputeHash(data, offset, count);
 			}
 #else
 			Sha256Digest sha256 = new Sha256Digest();
-			sha256.BlockUpdate(data, 0, count);
+			sha256.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[32];
 			sha256.DoFinal(rv, 0);
 			return rv;
@@ -83,16 +77,16 @@ namespace NBitcoin.Crypto
 
 
 
-		public static byte[] RIPEMD160(byte[] data, int count)
+		public static byte[] RIPEMD160(byte[] data, int offset, int count)
 		{
 #if !USEBC
 			using(var ripm = System.Security.Cryptography.RIPEMD160.Create())
 			{
-				return ripm.ComputeHash(data, 0, count);
+				return ripm.ComputeHash(data, offset, count);
 			}
 #else
 			RipeMD160Digest ripemd = new RipeMD160Digest();
-			ripemd.BlockUpdate(data, 0, count);
+			ripemd.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[20];
 			ripemd.DoFinal(rv, 0);
 			return rv;
@@ -113,6 +107,7 @@ namespace NBitcoin.Crypto
 			h ^= h >> 16;
 			return h;
 		}
+
 		public static uint MurmurHash3(uint nHashSeed, byte[] vDataToHash)
 		{
 			// The following is MurmurHash3 (x86_32), see https://gist.github.com/automatonic/3725443
@@ -182,15 +177,12 @@ namespace NBitcoin.Crypto
 			h1 ^= streamLength;
 			h1 = fmix(h1);
 
-			unchecked //ignore overflow
-			{
-				return h1;
-			}
+			return h1;
 		}
 
 		internal static uint160 Hash160(byte[] bytes)
 		{
-			return Hash160(bytes, bytes.Length);
+			return Hash160(bytes, 0, bytes.Length);
 		}
 #if !USEBC
 		public static byte[] HMACSHA512(byte[] key, byte[] data)
@@ -210,16 +202,16 @@ namespace NBitcoin.Crypto
 #endif
 		public static byte[] BIP32Hash(byte[] chainCode, uint nChild, byte header, byte[] data)
 		{
-			byte[] num = new byte[4];
-			num[0] = (byte)((nChild >> 24) & 0xFF);
-			num[1] = (byte)((nChild >> 16) & 0xFF);
-			num[2] = (byte)((nChild >> 8) & 0xFF);
-			num[3] = (byte)((nChild >> 0) & 0xFF);
+			var num = BitConverter.GetBytes(nChild);
+			Array.Reverse(num);
 
-			return HMACSHA512(chainCode,
-				new byte[] { header }
-				.Concat(data)
-				.Concat(num).ToArray());
+			var newData = new byte[1 + num.Length + data.Length];
+			newData[0] = header;	
+
+			Buffer.BlockCopy(data, 0, newData, 1, data.Length);
+			Buffer.BlockCopy(num, 0, newData, data.Length + 1, num.Length);
+
+			return HMACSHA512(chainCode, newData);;
 		}
 	}
 }

--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -1,10 +1,7 @@
 ﻿using NBitcoin.Crypto;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NBitcoin.DataEncoders
 {
@@ -15,9 +12,9 @@ namespace NBitcoin.DataEncoders
 			if(Check)
 			{
 				var toEncode = new byte[count + 4];
-				Buffer.BlockCopy(data, 0, toEncode, 0, count);
+				Buffer.BlockCopy(data, offset, toEncode, 0, count);
 
-				var hash = Hashes.Hash256(data, count).ToBytes();
+				var hash = Hashes.Hash256(data, offset, count).ToBytes();
 				Buffer.BlockCopy(hash, 0, toEncode, count, 4);
 
 				return EncodeDataCore(toEncode, toEncode.Length);
@@ -79,7 +76,7 @@ namespace NBitcoin.DataEncoders
 					Array.Clear(vchRet, 0, vchRet.Length);
 					throw new FormatException("Invalid checked base 58 string");
 				}
-				var calculatedHash = Hashes.Hash256(vchRet, vchRet.Length - 4).ToBytes().Take(4).ToArray();
+				var calculatedHash = Hashes.Hash256(vchRet, 0, vchRet.Length - 4).ToBytes().Take(4).ToArray();
 				var expectedHash = vchRet.Skip(vchRet.Length - 4).Take(4).ToArray();
 
 				if(!Utils.ArrayEqual(calculatedHash, expectedHash))

--- a/NBitcoin/Payment/PaymentRequest.cs
+++ b/NBitcoin/Payment/PaymentRequest.cs
@@ -458,7 +458,7 @@ namespace NBitcoin.Payment
 			}
 			else if(PKIType == Payment.PKIType.X509SHA1)
 			{
-				hash = Hashes.SHA1(data, data.Length);
+				hash = Hashes.SHA1(data, 0, data.Length);
 				hashName = "sha1";
 			}
 			else
@@ -494,7 +494,7 @@ namespace NBitcoin.Payment
 			}
 			else if(type == Payment.PKIType.X509SHA1)
 			{
-				hash = Hashes.SHA1(data, data.Length);
+				hash = Hashes.SHA1(data, 0, data.Length);
 				hashName = "sha1";
 			}
 			else

--- a/NBitcoin/Protocol/Message.cs
+++ b/NBitcoin/Protocol/Message.cs
@@ -79,7 +79,7 @@ namespace NBitcoin.Protocol
 			if(stream.ProtocolVersion >= ProtocolVersion.MEMPOOL_GD_VERSION)
 			{
 				if(stream.Serializing)
-					checksum = Hashes.Hash256(payloadBytes, length).GetLow32();
+					checksum = Hashes.Hash256(payloadBytes, 0, length).GetLow32();
 				stream.ReadWrite(ref checksum);
 				hasChecksum = true;
 			}
@@ -139,7 +139,7 @@ namespace NBitcoin.Protocol
 
 		internal static bool VerifyChecksum(uint256 checksum, byte[] payload, int length)
 		{
-			return checksum == Hashes.Hash256(payload, length).GetLow32();
+			return checksum == Hashes.Hash256(payload, 0, length).GetLow32();
 		}
 
 

--- a/NBitcoin/PubKey.cs
+++ b/NBitcoin/PubKey.cs
@@ -118,7 +118,7 @@ namespace NBitcoin
 			{
 				if(_ID == null)
 				{
-					_ID = new KeyId(Hashes.Hash160(vch, vch.Length));
+					_ID = new KeyId(Hashes.Hash160(vch, 0, vch.Length));
 				}
 				return _ID;
 			}

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -938,15 +938,15 @@ namespace NBitcoin
 									var vch = top(_Stack, -1);
 									byte[] vchHash = null;//((opcode == OpcodeType.OP_RIPEMD160 || opcode == OpcodeType.OP_SHA1 || opcode == OpcodeType.OP_HASH160) ? 20 : 32);
 									if(opcode.Code == OpcodeType.OP_RIPEMD160)
-										vchHash = Hashes.RIPEMD160(vch, vch.Length);
+										vchHash = Hashes.RIPEMD160(vch, 0, vch.Length);
 									else if(opcode.Code == OpcodeType.OP_SHA1)
-										vchHash = Hashes.SHA1(vch, vch.Length);
+										vchHash = Hashes.SHA1(vch, 0, vch.Length);
 									else if(opcode.Code == OpcodeType.OP_SHA256)
-										vchHash = Hashes.SHA256(vch, vch.Length);
+										vchHash = Hashes.SHA256(vch, 0, vch.Length);
 									else if(opcode.Code == OpcodeType.OP_HASH160)
-										vchHash = Hashes.Hash160(vch, vch.Length).ToBytes();
+										vchHash = Hashes.Hash160(vch, 0, vch.Length).ToBytes();
 									else if(opcode.Code == OpcodeType.OP_HASH256)
-										vchHash = Hashes.Hash256(vch, vch.Length).ToBytes();
+										vchHash = Hashes.Hash256(vch, 0, vch.Length).ToBytes();
 									_Stack.Pop();
 									_Stack.Push(vchHash);
 								}

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -516,17 +516,17 @@ namespace NBitcoin
 		{
 			if(littleEndian)
 			{
-				return value[0]
-					   + ((uint)value[index + 1] << 8)
-					   + ((uint)value[index + 2] << 16)
-					   + ((uint)value[index + 3] << 24);
+				return value[index + 0]
+					+ ((uint)value[index + 1] << 8)
+					+ ((uint)value[index + 2] << 16)
+					+ ((uint)value[index + 3] << 24);
 			}
 			else
 			{
-				return value[3]
-					   + ((uint)value[index + 2] << 8)
-					   + ((uint)value[index + 1] << 16)
-					   + ((uint)value[index + 0] << 24);
+				return value[index + 3]
+					+ ((uint)value[index + 2] << 8)
+					+ ((uint)value[index + 1] << 16)
+					+ ((uint)value[index + 0] << 24);
 			}
 		}
 


### PR DESCRIPTION
@NicolasDorier, this PR has minor changes similar to the previous once and also fix a problem in Utils.ToUnit32(). If you run the UTs (before merging this PR) you will see several tests in red.

By the way, if you want to have the flexibility to deal with system endianness, you should consider [Mono.DataConvert](http://www.mono-project.com/archived/mono_dataconvert/) (is not a library, it's a standalone class you can include in your projects). Mono,DataConvert is a very good piece of code really.