### PR TITLE
SafeSubarray method and minor changes

### DIFF
--- a/NBitcoin/BIP32/ExtKey.cs
+++ b/NBitcoin/BIP32/ExtKey.cs
@@ -78,8 +78,9 @@ namespace NBitcoin
 		private void SetMaster(byte[] seed)
 		{
 			var hashMAC = Hashes.HMACSHA512(hashkey, seed);
-			key = new Key(hashMAC.Take(32).ToArray());
-			Array.Copy(hashMAC.Skip(32).Take(32).ToArray(), 0, vchChainCode, 0, vchChainCode.Length);
+			key = new Key(hashMAC.SafeSubarray(0, 32));
+
+			Buffer.BlockCopy(hashMAC, 32, vchChainCode, 0, 32);
 		}
 
 		/// <summary>
@@ -111,7 +112,7 @@ namespace NBitcoin
 		}
 		private byte[] CalculateChildFingerprint()
 		{
-			return key.PubKey.Hash.ToBytes().Take(vchFingerprint.Length).ToArray();
+			return key.PubKey.Hash.ToBytes().SafeSubarray(0, vchFingerprint.Length);
 		}
 
 		public byte[] Fingerprint
@@ -213,7 +214,7 @@ namespace NBitcoin
 			byte[] lr = new byte[32];
 
 			var pubKey = parent.PubKey.ToBytes();
-			l = Hashes.BIP32Hash(parent.vchChainCode, nChild, pubKey[0], pubKey.Skip(1).ToArray());
+			l = Hashes.BIP32Hash(parent.vchChainCode, nChild, pubKey[0], pubKey.SafeSubarray(1));
 			Array.Copy(l, ll, 32);
 			Array.Copy(l, 32, lr, 0, 32);
 			var ccChild = lr;

--- a/NBitcoin/BIP32/ExtPubKey.cs
+++ b/NBitcoin/BIP32/ExtPubKey.cs
@@ -1,4 +1,5 @@
-﻿using NBitcoin.Crypto;
+﻿using System;
+using NBitcoin.Crypto;
 using NBitcoin.DataEncoders;
 using System.Linq;
 
@@ -70,7 +71,7 @@ namespace NBitcoin
 		}
 		public byte[] CalculateChildFingerprint()
 		{
-			return pubkey.Hash.ToBytes().Take(vchFingerprint.Length).ToArray();
+			return pubkey.Hash.ToBytes().SafeSubarray(0, vchFingerprint.Length);
 		}
 
 		public byte[] Fingerprint

--- a/NBitcoin/BIP38/BitcoinConfirmationCode.cs
+++ b/NBitcoin/BIP38/BitcoinConfirmationCode.cs
@@ -22,7 +22,7 @@ namespace NBitcoin
 		byte[] _AddressHash;
 		public byte[] AddressHash
 		{
-			get { return _AddressHash ?? (_AddressHash = vchData.Skip(1).Take(4).ToArray()); }
+			get { return _AddressHash ?? (_AddressHash = vchData.SafeSubarray(1, 4)); }
 		}
 		public bool IsCompressed
 		{
@@ -34,7 +34,7 @@ namespace NBitcoin
 		byte[] _OwnerEntropy;
 		public byte[] OwnerEntropy
 		{
-			get { return _OwnerEntropy ?? (_OwnerEntropy = vchData.Skip(1).Skip(4).Take(8).ToArray()); }
+			get { return _OwnerEntropy ?? (_OwnerEntropy = vchData.SafeSubarray(5, 8)); }
 		}
 		LotSequence _LotSequence;
 		public LotSequence LotSequence
@@ -46,7 +46,7 @@ namespace NBitcoin
 					return null;
 				if(_LotSequence == null)
 				{
-					_LotSequence = new LotSequence(OwnerEntropy.Skip(4).Take(4).ToArray());
+					_LotSequence = new LotSequence(OwnerEntropy.SafeSubarray(4, 4));
 				}
 				return _LotSequence;
 			}
@@ -55,7 +55,7 @@ namespace NBitcoin
 		byte[] _EncryptedPointB;
 		byte[] EncryptedPointB
 		{
-			get { return _EncryptedPointB ?? (_EncryptedPointB = vchData.Skip(1).Skip(4).Skip(8).ToArray()); }
+			get { return _EncryptedPointB ?? (_EncryptedPointB = vchData.SafeSubarray(13)); }
 		}
 
 		public override Base58Type Type

--- a/NBitcoin/Base58Data.cs
+++ b/NBitcoin/Base58Data.cs
@@ -55,11 +55,11 @@ namespace NBitcoin
 			var expectedVersion = _Network.GetVersionBytes(Type);
 
 
-			vchVersion = vchTemp.Take((int)expectedVersion.Length).ToArray();
+			vchVersion = vchTemp.SafeSubarray(0, expectedVersion.Length);
 			if(!Utils.ArrayEqual(vchVersion, expectedVersion))
 				throw new FormatException("The version prefix does not match the expected one " + String.Join(",", expectedVersion));
 
-			vchData = vchTemp.Skip((int)expectedVersion.Length).ToArray();
+			vchData = vchTemp.SafeSubarray(expectedVersion.Length);
 			wifData = psz;
 
 			if(!IsValid)

--- a/NBitcoin/BitcoinAddress.cs
+++ b/NBitcoin/BitcoinAddress.cs
@@ -112,8 +112,10 @@ namespace NBitcoin
 
 		public BitcoinScriptAddress GetScriptAddress()
 		{
-			if(this is BitcoinScriptAddress)
-				return (BitcoinScriptAddress)this;
+			var bitcoinScriptAddress = this as BitcoinScriptAddress;
+			if (bitcoinScriptAddress != null)
+				return bitcoinScriptAddress;
+
 			var redeem = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(this);
 			return new BitcoinScriptAddress(redeem.Hash, Network);
 		}
@@ -147,10 +149,10 @@ namespace NBitcoin
 				throw new ArgumentNullException("network");
 			if(id is KeyId)
 				return new BitcoinAddress(id, network);
-			else if(id is ScriptId)
+			if(id is ScriptId)
 				return new BitcoinScriptAddress((ScriptId)id, network);
-			else
-				throw new NotSupportedException();
+			
+			throw new NotSupportedException();
 		}
 
 		public BitcoinColoredAddress ToColoredAddress()

--- a/NBitcoin/BitcoinSecret.cs
+++ b/NBitcoin/BitcoinSecret.cs
@@ -31,10 +31,7 @@ namespace NBitcoin
 
 		public BitcoinAddress GetAddress()
 		{
-			if(_address == null)
-				_address = PrivateKey.PubKey.GetAddress(Network);
-
-			return _address;
+			return _address ?? (_address = PrivateKey.PubKey.GetAddress(Network));
 		}
 
 		public virtual KeyId PubKeyHash
@@ -57,12 +54,7 @@ namespace NBitcoin
 		Key _Key;
 		public Key PrivateKey
 		{
-			get
-			{
-				if(_Key == null)
-					_Key = new Key(vchData, 32, IsCompressed);
-				return _Key;
-			}
+			get { return _Key ?? (_Key = new Key(vchData, 32, IsCompressed)); }
 		}
 		#endregion
 

--- a/NBitcoin/Block.cs
+++ b/NBitcoin/Block.cs
@@ -163,9 +163,7 @@ namespace NBitcoin
 		public bool CheckProofOfWork()
 		{
 			// Check proof of work matches claimed amount
-			if(GetHash() > Bits.ToUInt256())
-				return false;
-			return true;
+			return GetHash() <= Bits.ToUInt256();
 		}
 
 		public override string ToString()
@@ -177,7 +175,9 @@ namespace NBitcoin
 
 	public class Block : IBitcoinSerializable
 	{
-		public const uint MAX_BLOCK_SIZE = 1000000;
+		//FIXME: it needs to be changed when Gavin Andresen increase the max block size. 
+		public const uint MAX_BLOCK_SIZE = 1000 * 000;
+
 		BlockHeader header = new BlockHeader();
 		// network and disk
 		List<Transaction> vtx = new List<Transaction>();

--- a/NBitcoin/Block.cs
+++ b/NBitcoin/Block.cs
@@ -176,7 +176,7 @@ namespace NBitcoin
 	public class Block : IBitcoinSerializable
 	{
 		//FIXME: it needs to be changed when Gavin Andresen increase the max block size. 
-		public const uint MAX_BLOCK_SIZE = 1000 * 000;
+		public const uint MAX_BLOCK_SIZE = 1000 * 1000;
 
 		BlockHeader header = new BlockHeader();
 		// network and disk

--- a/NBitcoin/BlockLocator.cs
+++ b/NBitcoin/BlockLocator.cs
@@ -15,9 +15,9 @@ namespace NBitcoin
 		{
 
 		}
-		public BlockLocator(IEnumerable<uint256> hashes)
+		public BlockLocator(List<uint256> hashes)
 		{
-			vHave = hashes.ToList();
+			vHave = hashes;
 		}
 
 		List<uint256> vHave = new List<uint256>();

--- a/NBitcoin/BlockLocator.cs
+++ b/NBitcoin/BlockLocator.cs
@@ -15,9 +15,9 @@ namespace NBitcoin
 		{
 
 		}
-		public BlockLocator(List<uint256> hashes)
+		public BlockLocator(IEnumerable<uint256> hashes)
 		{
-			vHave = hashes;
+			vHave = hashes.ToList();
 		}
 
 		List<uint256> vHave = new List<uint256>();

--- a/NBitcoin/ChainedBlock.cs
+++ b/NBitcoin/ChainedBlock.cs
@@ -250,8 +250,8 @@ namespace NBitcoin
 			if(Height != 0 && Previous == null)
 				return false;
 			var heightCorrect = Height == 0 || Height == Previous.Height + 1;
-			var genesisCorrect = Height == 0 ? HashBlock == network.GetGenesis().GetHash() : true;
-			var hashPrevCorrect = Height == 0 ? true : Header.HashPrevBlock == Previous.HashBlock;
+			var genesisCorrect = Height != 0 || HashBlock == network.GetGenesis().GetHash();
+			var hashPrevCorrect = Height == 0 || Header.HashPrevBlock == Previous.HashBlock;
 			var hashCorrect = HashBlock == Header.GetHash();
 			var workCorrect = CheckProofOfWorkAndTarget(network);
 			return heightCorrect && genesisCorrect && hashPrevCorrect && hashCorrect && workCorrect;

--- a/NBitcoin/Coin.cs
+++ b/NBitcoin/Coin.cs
@@ -364,8 +364,9 @@ namespace NBitcoin
 		{
 			if(redeemScript == null)
 				throw new ArgumentNullException("redeemScript");
-			if(this is ScriptCoin)
-				return (ScriptCoin)this;
+			var scriptCoin = this as ScriptCoin;
+			if (scriptCoin != null)
+				return scriptCoin;
 			return new ScriptCoin(this, redeemScript);
 		}
 

--- a/NBitcoin/ConcurrentChain.cs
+++ b/NBitcoin/ConcurrentChain.cs
@@ -61,7 +61,7 @@ namespace NBitcoin
 						uint256 id = null;
 						stream.ReadWrite<uint256>(ref id);
 						BlockHeader header = null;
-						stream.ReadWrite<BlockHeader>(ref header);
+						stream.ReadWrite(ref header);
 						if(height == 0)
 						{
 							_BlocksByHeight.Clear();

--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -16,6 +16,17 @@ namespace NBitcoin.Crypto
 {
 	public class Hashes
 	{
+		#region Hash256
+		public static uint256 Hash256(byte[] data)
+		{
+			return Hash256(data, 0, data.Length);
+		}
+
+		public static uint256 Hash256(byte[] data, int count)
+		{
+			return Hash256(data, 0, count);
+		}
+
 		public static uint256 Hash256(byte[] data, int offset, int count)
 		{
 			//data = count == 0 ? new byte[1] : data;
@@ -35,23 +46,54 @@ namespace NBitcoin.Crypto
 			return new uint256(rv);
 #endif
 		}
+		#endregion
 
-
-		public static uint256 Hash256(byte[] data)
+		#region Hash160
+		public static uint160 Hash160(byte[] data)
 		{
-			return Hash256(data, 0, data.Length);
+			return Hash160(data, 0, data.Length);
+		}
+
+		public static uint160 Hash160(byte[] data, int count)
+		{
+			return Hash160(data, 0, count);
 		}
 
 		public static uint160 Hash160(byte[] data, int offset, int count)
 		{
-			//data = count == 0 ? new byte[1] : data;
 			return new uint160(RIPEMD160(SHA256(data, offset, count)));
 		}
+		#endregion
 
+		#region RIPEMD160
 		private static byte[] RIPEMD160(byte[] data)
 		{
 			return RIPEMD160(data, 0, data.Length);
 		}
+
+		public static byte[] RIPEMD160(byte[] data, int count)
+		{
+			return RIPEMD160(data, 0, count);
+		}
+
+		public static byte[] RIPEMD160(byte[] data, int offset, int count)
+		{
+#if !USEBC
+			using (var ripm = new RIPEMD160Managed())
+			{
+				return ripm.ComputeHash(data, offset, count);
+			}
+#else
+			RipeMD160Digest ripemd = new RipeMD160Digest();
+			ripemd.BlockUpdate(data, offset, count);
+			byte[] rv = new byte[20];
+			ripemd.DoFinal(rv, 0);
+			return rv;
+#endif
+		}
+
+		#endregion
+
 		public static byte[] SHA1(byte[] data, int offset, int count)
 		{
 			var sha1 = new Sha1Digest();
@@ -65,6 +107,7 @@ namespace NBitcoin.Crypto
 		{
 			return SHA256(data, 0, data.Length);
 		}
+
 		public static byte[] SHA256(byte[] data, int offset, int count)
 		{
 #if !USEBC
@@ -81,23 +124,6 @@ namespace NBitcoin.Crypto
 #endif
 		}
 
-
-
-		public static byte[] RIPEMD160(byte[] data, int offset, int count)
-		{
-#if !USEBC
-			using(var ripm = new RIPEMD160Managed())
-			{
-				return ripm.ComputeHash(data, offset, count);
-			}
-#else
-			RipeMD160Digest ripemd = new RipeMD160Digest();
-			ripemd.BlockUpdate(data, offset, count);
-			byte[] rv = new byte[20];
-			ripemd.DoFinal(rv, 0);
-			return rv;
-#endif
-		}
 
 		private static uint rotl32(uint x, byte r)
 		{
@@ -182,13 +208,12 @@ namespace NBitcoin.Crypto
 			h1 ^= streamLength;
 			h1 = fmix(h1);
 
-			return h1;
+			unchecked //ignore overflow
+			{
+				return h1;
+			}
 		}
 
-		internal static uint160 Hash160(byte[] bytes)
-		{
-			return Hash160(bytes, 0, bytes.Length);
-		}
 #if !USEBC
 		public static byte[] HMACSHA512(byte[] key, byte[] data)
 		{

--- a/NBitcoin/Crypto/Hashes.cs
+++ b/NBitcoin/Crypto/Hashes.cs
@@ -16,18 +16,18 @@ namespace NBitcoin.Crypto
 {
 	public class Hashes
 	{
-		public static uint256 Hash256(byte[] data, int count)
+		public static uint256 Hash256(byte[] data, int offset, int count)
 		{
-			data = count == 0 ? new byte[1] : data;
+			//data = count == 0 ? new byte[1] : data;
 #if !USEBC
 			using(var sha = new SHA256Managed())
 			{
-				var h = sha.ComputeHash(data, 0, count);
+				var h = sha.ComputeHash(data, offset, count);
 				return new uint256(sha.ComputeHash(h, 0, h.Length));
 			}
 #else
 			Sha256Digest sha256 = new Sha256Digest();
-			sha256.BlockUpdate(data, 0, count);
+			sha256.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[32];
 			sha256.DoFinal(rv, 0);
 			sha256.BlockUpdate(rv, 0, rv.Length);
@@ -39,23 +39,23 @@ namespace NBitcoin.Crypto
 
 		public static uint256 Hash256(byte[] data)
 		{
-			return Hash256(data, data.Length);
+			return Hash256(data, 0, data.Length);
 		}
 
-		public static uint160 Hash160(byte[] data, int count)
+		public static uint160 Hash160(byte[] data, int offset, int count)
 		{
-			data = count == 0 ? new byte[1] : data;
-			return new uint160(RIPEMD160(SHA256(data, count)));
+			//data = count == 0 ? new byte[1] : data;
+			return new uint160(RIPEMD160(SHA256(data, offset, count)));
 		}
 
 		private static byte[] RIPEMD160(byte[] data)
 		{
-			return RIPEMD160(data, data.Length);
+			return RIPEMD160(data, 0, data.Length);
 		}
-		public static byte[] SHA1(byte[] data, int count)
+		public static byte[] SHA1(byte[] data, int offset, int count)
 		{
 			var sha1 = new Sha1Digest();
-			sha1.BlockUpdate(data, 0, count);
+			sha1.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[20];
 			sha1.DoFinal(rv, 0);
 			return rv;
@@ -63,18 +63,18 @@ namespace NBitcoin.Crypto
 
 		public static byte[] SHA256(byte[] data)
 		{
-			return SHA256(data, data.Length);
+			return SHA256(data, 0, data.Length);
 		}
-		public static byte[] SHA256(byte[] data, int count)
+		public static byte[] SHA256(byte[] data, int offset, int count)
 		{
 #if !USEBC
 			using(var sha = new SHA256Managed())
 			{
-				return sha.ComputeHash(data, 0, count);
+				return sha.ComputeHash(data, offset, count);
 			}
 #else
 			Sha256Digest sha256 = new Sha256Digest();
-			sha256.BlockUpdate(data, 0, count);
+			sha256.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[32];
 			sha256.DoFinal(rv, 0);
 			return rv;
@@ -83,16 +83,16 @@ namespace NBitcoin.Crypto
 
 
 
-		public static byte[] RIPEMD160(byte[] data, int count)
+		public static byte[] RIPEMD160(byte[] data, int offset, int count)
 		{
 #if !USEBC
 			using(var ripm = new RIPEMD160Managed())
 			{
-				return ripm.ComputeHash(data, 0, count);
+				return ripm.ComputeHash(data, offset, count);
 			}
 #else
 			RipeMD160Digest ripemd = new RipeMD160Digest();
-			ripemd.BlockUpdate(data, 0, count);
+			ripemd.BlockUpdate(data, offset, count);
 			byte[] rv = new byte[20];
 			ripemd.DoFinal(rv, 0);
 			return rv;
@@ -182,15 +182,12 @@ namespace NBitcoin.Crypto
 			h1 ^= streamLength;
 			h1 = fmix(h1);
 
-			unchecked //ignore overflow
-			{
-				return h1;
-			}
+			return h1;
 		}
 
 		internal static uint160 Hash160(byte[] bytes)
 		{
-			return Hash160(bytes, bytes.Length);
+			return Hash160(bytes, 0, bytes.Length);
 		}
 #if !USEBC
 		public static byte[] HMACSHA512(byte[] key, byte[] data)

--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -1,10 +1,7 @@
 ﻿using NBitcoin.Crypto;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NBitcoin.DataEncoders
 {
@@ -15,9 +12,9 @@ namespace NBitcoin.DataEncoders
 			if(Check)
 			{
 				var toEncode = new byte[count + 4];
-				Buffer.BlockCopy(data, 0, toEncode, 0, count);
+				Buffer.BlockCopy(data, offset, toEncode, 0, count);
 
-				var hash = Hashes.Hash256(data, count).ToBytes();
+				var hash = Hashes.Hash256(data, offset, count).ToBytes();
 				Buffer.BlockCopy(hash, 0, toEncode, count, 4);
 
 				return EncodeDataCore(toEncode, toEncode.Length);
@@ -79,15 +76,15 @@ namespace NBitcoin.DataEncoders
 					Array.Clear(vchRet, 0, vchRet.Length);
 					throw new FormatException("Invalid checked base 58 string");
 				}
-				var calculatedHash = Hashes.Hash256(vchRet, vchRet.Length - 4).ToBytes().Take(4).ToArray();
-				var expectedHash = vchRet.Skip(vchRet.Length - 4).Take(4).ToArray();
+				var calculatedHash = Hashes.Hash256(vchRet, 0, vchRet.Length - 4).ToBytes().SafeSubarray(0, 4);
+				var expectedHash = vchRet.SafeSubarray(vchRet.Length - 4, 4);
 
 				if(!Utils.ArrayEqual(calculatedHash, expectedHash))
 				{
 					Array.Clear(vchRet, 0, vchRet.Length);
 					throw new FormatException("Invalid hash of the base 58 string");
 				}
-				vchRet = vchRet.Take(vchRet.Length - 4).ToArray();
+				vchRet = vchRet.SafeSubarray(0, vchRet.Length - 4);
 				return vchRet;
 			}
 
@@ -137,7 +134,7 @@ namespace NBitcoin.DataEncoders
 
 			// Trim off sign byte if present
 			if(vchTmp.Length >= 2 && vchTmp[vchTmp.Length - 1] == 0 && vchTmp[vchTmp.Length - 2] >= 0x80)
-				vchTmp = vchTmp.Take(vchTmp.Length - 1).ToArray();
+				vchTmp = vchTmp.SafeSubarray(0, vchTmp.Length - 1);
 
 			// Restore leading zeros
 			int nLeadingZeros = 0;

--- a/NBitcoin/IBlockRepository.cs
+++ b/NBitcoin/IBlockRepository.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace NBitcoin
 {
@@ -10,5 +6,4 @@ namespace NBitcoin
 	{
 		Task<Block> GetBlockAsync(uint256 blockId);
 	}
-	
 }

--- a/NBitcoin/IDestination.cs
+++ b/NBitcoin/IDestination.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace NBitcoin
+﻿namespace NBitcoin
 {
 	/// <summary>
 	/// Represent any type which represent an underlying ScriptPubKey

--- a/NBitcoin/ISecret.cs
+++ b/NBitcoin/ISecret.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace NBitcoin
+﻿namespace NBitcoin
 {
 	public interface ISecret
 	{

--- a/NBitcoin/ITransactionRepository.cs
+++ b/NBitcoin/ITransactionRepository.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.ExceptionServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace NBitcoin

--- a/NBitcoin/IpExtensions.cs
+++ b/NBitcoin/IpExtensions.cs
@@ -56,7 +56,7 @@ namespace NBitcoin
 		{
 			var bytes = address.GetAddressBytes();
 			byte[] pchRFC6052 = new byte[] { 0, 0x64, 0xFF, 0x9B, 0, 0, 0, 0, 0, 0, 0, 0 };
-			return (memcmp(bytes, pchRFC6052, pchRFC6052.Length) == 0);
+			return ((Utils.ArrayEqual(bytes, 0, pchRFC6052, 0, pchRFC6052.Length) ? 0 : 1) == 0);
 		}
 
 		public static bool IsRFC4380(this IPAddress address)
@@ -69,7 +69,7 @@ namespace NBitcoin
 		{
 			var bytes = address.GetAddressBytes();
 			byte[] pchRFC4862 = new byte[] { 0xFE, 0x80, 0, 0, 0, 0, 0, 0 };
-			return (memcmp(bytes, pchRFC4862, pchRFC4862.Length) == 0);
+			return ((Utils.ArrayEqual(bytes, 0, pchRFC4862, 0, pchRFC4862.Length) ? 0 : 1) == 0);
 		}
 
 		public static bool IsRFC4193(this IPAddress address)
@@ -82,7 +82,7 @@ namespace NBitcoin
 		{
 			var bytes = address.GetAddressBytes();
 			byte[] pchRFC6145 = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0, 0 };
-			return (memcmp(bytes, pchRFC6145, pchRFC6145.Length) == 0);
+			return ((Utils.ArrayEqual(bytes, 0, pchRFC6145, 0, pchRFC6145.Length) ? 0 : 1) == 0);
 		}
 
 		public static bool IsRFC4843(this IPAddress address)
@@ -166,7 +166,7 @@ namespace NBitcoin
 		public static bool IsTor(this IPAddress address)
 		{
 			var bytes = address.GetAddressBytes();
-			return (memcmp(bytes, pchOnionCat, pchOnionCat.Length) == 0);
+			return ((Utils.ArrayEqual(bytes, 0, pchOnionCat, 0, pchOnionCat.Length) ? 0 : 1) == 0);
 		}
 		public static IPAddress EnsureIPv6(this IPAddress address)
 		{
@@ -184,15 +184,10 @@ namespace NBitcoin
 
 			// IPv6 loopback (::1/128)
 			byte[] pchLocal = new byte[16] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
-			if(memcmp(bytes, pchLocal, 16) == 0)
+			if((Utils.ArrayEqual(bytes, 0, pchLocal, 0, 16) ? 0 : 1) == 0)
 				return true;
 
 			return false;
-		}
-
-		private static int memcmp(byte[] a, byte[] b, int n)
-		{
-			return Utils.ArrayEqual(a, 0, b, 0, n) ? 0 : 1;
 		}
 
 		public static bool IsMulticast(this IPAddress address)
@@ -221,7 +216,7 @@ namespace NBitcoin
 			var ip = address.GetAddressBytes();
 			// unspecified IPv6 address (::/128)
 			byte[] ipNone = new byte[16];
-			if(memcmp(ip, ipNone, 16) == 0)
+			if((Utils.ArrayEqual(ip, 0, ipNone, 0, 16) ? 0 : 1) == 0)
 				return false;
 
 			// documentation IPv6 address

--- a/NBitcoin/Key.cs
+++ b/NBitcoin/Key.cs
@@ -69,8 +69,7 @@ namespace NBitcoin
 
 		private void SetBytes(byte[] data, int count, bool fCompressedIn)
 		{
-			vch = new byte[KEY_SIZE];
-			Array.Copy(data, 0, vch, 0, count);
+			vch = data.SafeSubarray(0, count);
 			IsCompressed = fCompressedIn;
 			_ECKey = new ECKey(vch, true);
 		}
@@ -181,24 +180,23 @@ namespace NBitcoin
 		public Key Derivate(byte[] cc, uint nChild, out byte[] ccChild)
 		{
 			byte[] l = null;
-			byte[] ll = new byte[32];
-			byte[] lr = new byte[32];
 			if((nChild >> 31) == 0)
 			{
 				var pubKey = PubKey.ToBytes();
-				l = Hashes.BIP32Hash(cc, nChild, pubKey[0], pubKey.Skip(1).ToArray());
+				l = Hashes.BIP32Hash(cc, nChild, pubKey[0], pubKey.SafeSubarray(1));
 			}
 			else
 			{
 				l = Hashes.BIP32Hash(cc, nChild, 0, this.ToBytes());
 			}
-			Array.Copy(l, ll, 32);
-			Array.Copy(l, 32, lr, 0, 32);
+			var ll = l.SafeSubarray(0, 32);
+			var lr = l.SafeSubarray(32, 32);
+
 			ccChild = lr;
 
-			BigInteger parse256LL = new BigInteger(1, ll);
-			BigInteger kPar = new BigInteger(1, vch);
-			BigInteger N = ECKey.CURVE.N;
+			var parse256LL = new BigInteger(1, ll);
+			var kPar = new BigInteger(1, vch);
+			var N = ECKey.CURVE.N;
 
 			if(parse256LL.CompareTo(N) >= 0)
 				throw new InvalidOperationException("You won a prize ! this should happen very rarely. Take a screenshot, and roll the dice again.");

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -187,7 +187,7 @@ namespace NBitcoin
 			// The characters are rarely used upper ASCII, not valid as UTF-8, and produce
 			// a large 4-byte int at any alignment.
 			magic = 0xD9B4BEF9;
-			vAlertPubKey = DataEncoders.Encoders.Hex.DecodeData("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284");
+			vAlertPubKey = Encoders.Hex.DecodeData("04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284");
 			nDefaultPort = 8333;
 			nRPCPort = 8332;
 			_ProofOfLimit = new Target(~new uint256(0) >> 32);
@@ -197,9 +197,9 @@ namespace NBitcoin
 			txNew.Version = 1;
 			txNew.Inputs.Add(new TxIn());
 			txNew.Outputs.Add(new TxOut());
-			txNew.Inputs[0].ScriptSig = new Script(DataEncoders.Encoders.Hex.DecodeData("04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
+			txNew.Inputs[0].ScriptSig = new Script(Encoders.Hex.DecodeData("04ffff001d0104455468652054696d65732030332f4a616e2f32303039204368616e63656c6c6f72206f6e206272696e6b206f66207365636f6e64206261696c6f757420666f722062616e6b73"));
 			txNew.Outputs[0].Value = 50 * Money.COIN;
-			txNew.Outputs[0].ScriptPubKey = new Script() + DataEncoders.Encoders.Hex.DecodeData("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") + OpcodeType.OP_CHECKSIG;
+			txNew.Outputs[0].ScriptPubKey = new Script() + Encoders.Hex.DecodeData("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") + OpcodeType.OP_CHECKSIG;
 			genesis.Transactions.Add(txNew);
 			genesis.Header.HashPrevBlock = 0;
 			genesis.UpdateMerkleRoot();

--- a/NBitcoin/Payment/PaymentRequest.cs
+++ b/NBitcoin/Payment/PaymentRequest.cs
@@ -458,7 +458,7 @@ namespace NBitcoin.Payment
 			}
 			else if(PKIType == Payment.PKIType.X509SHA1)
 			{
-				hash = Hashes.SHA1(data, data.Length);
+				hash = Hashes.SHA1(data, 0, data.Length);
 				hashName = "sha1";
 			}
 			else
@@ -494,7 +494,7 @@ namespace NBitcoin.Payment
 			}
 			else if(type == Payment.PKIType.X509SHA1)
 			{
-				hash = Hashes.SHA1(data, data.Length);
+				hash = Hashes.SHA1(data, 0, data.Length);
 				hashName = "sha1";
 			}
 			else

--- a/NBitcoin/Protocol/Message.cs
+++ b/NBitcoin/Protocol/Message.cs
@@ -79,7 +79,7 @@ namespace NBitcoin.Protocol
 			if(stream.ProtocolVersion >= ProtocolVersion.MEMPOOL_GD_VERSION)
 			{
 				if(stream.Serializing)
-					checksum = Hashes.Hash256(payloadBytes, length).GetLow32();
+					checksum = Hashes.Hash256(payloadBytes, 0, length).GetLow32();
 				stream.ReadWrite(ref checksum);
 				hasChecksum = true;
 			}
@@ -139,7 +139,7 @@ namespace NBitcoin.Protocol
 
 		internal static bool VerifyChecksum(uint256 checksum, byte[] payload, int length)
 		{
-			return checksum == Hashes.Hash256(payload, length).GetLow32();
+			return checksum == Hashes.Hash256(payload, 0, length).GetLow32();
 		}
 
 

--- a/NBitcoin/PubKey.cs
+++ b/NBitcoin/PubKey.cs
@@ -118,7 +118,7 @@ namespace NBitcoin
 			{
 				if(_ID == null)
 				{
-					_ID = new KeyId(Hashes.Hash160(vch, vch.Length));
+					_ID = new KeyId(Hashes.Hash160(vch, 0, vch.Length));
 				}
 				return _ID;
 			}
@@ -220,8 +220,8 @@ namespace NBitcoin
 			if(header < 27 || header > 34)
 				throw new ArgumentException("Header byte out of range: " + header);
 
-			BigInteger r = new BigInteger(1, signatureEncoded.Skip(1).Take(32).ToArray());
-			BigInteger s = new BigInteger(1, signatureEncoded.Skip(33).Take(32).ToArray());
+			BigInteger r = new BigInteger(1, signatureEncoded.SafeSubarray(1, 32));
+			BigInteger s = new BigInteger(1, signatureEncoded.SafeSubarray(33, 32));
 			var sig = new ECDSASignature(r, s);
 			bool compressed = false;
 

--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -409,8 +409,8 @@ namespace NBitcoin
 
 		public override string ToString()
 		{
-			StringBuilder builder = new StringBuilder();
-			ScriptReader reader = new ScriptReader(_Script);		
+			var builder = new StringBuilder(2 * 1000);
+			var reader = new ScriptReader(_Script);
 
 			Op op;
 			while((op = reader.Read()) != null)
@@ -794,10 +794,14 @@ namespace NBitcoin
 		/// <returns></returns>
 		public static Script CreateFromDestination(TxDestination id)
 		{
-			if(id is ScriptId)
-				return PayToScriptHashTemplate.Instance.GenerateScriptPubKey((ScriptId)id);
-			if(id is KeyId)
-				return PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey((KeyId)id);
+			var scriptId = id as ScriptId;
+			if (scriptId != null)
+				return PayToScriptHashTemplate.Instance.GenerateScriptPubKey(scriptId);
+
+			var pubkeyHash = id as KeyId;
+			if (pubkeyHash != null)
+				return PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(pubkeyHash);
+
 			throw new NotSupportedException();
 		}
 

--- a/NBitcoin/Script.cs
+++ b/NBitcoin/Script.cs
@@ -409,7 +409,9 @@ namespace NBitcoin
 
 		public override string ToString()
 		{
-			var builder = new StringBuilder(2 * 1000);
+			// by default StringBuilder capacity is 16 (too small)
+			// 300 is enough for P2PKH
+			var builder = new StringBuilder(300); 
 			var reader = new ScriptReader(_Script);
 
 			Op op;

--- a/NBitcoin/ScriptEvaluationContext.cs
+++ b/NBitcoin/ScriptEvaluationContext.cs
@@ -938,15 +938,15 @@ namespace NBitcoin
 									var vch = top(_Stack, -1);
 									byte[] vchHash = null;//((opcode == OpcodeType.OP_RIPEMD160 || opcode == OpcodeType.OP_SHA1 || opcode == OpcodeType.OP_HASH160) ? 20 : 32);
 									if(opcode.Code == OpcodeType.OP_RIPEMD160)
-										vchHash = Hashes.RIPEMD160(vch, vch.Length);
+										vchHash = Hashes.RIPEMD160(vch, 0, vch.Length);
 									else if(opcode.Code == OpcodeType.OP_SHA1)
-										vchHash = Hashes.SHA1(vch, vch.Length);
+										vchHash = Hashes.SHA1(vch, 0, vch.Length);
 									else if(opcode.Code == OpcodeType.OP_SHA256)
-										vchHash = Hashes.SHA256(vch, vch.Length);
+										vchHash = Hashes.SHA256(vch, 0, vch.Length);
 									else if(opcode.Code == OpcodeType.OP_HASH160)
-										vchHash = Hashes.Hash160(vch, vch.Length).ToBytes();
+										vchHash = Hashes.Hash160(vch, 0, vch.Length).ToBytes();
 									else if(opcode.Code == OpcodeType.OP_HASH256)
-										vchHash = Hashes.Hash256(vch, vch.Length).ToBytes();
+										vchHash = Hashes.Hash256(vch, 0, vch.Length).ToBytes();
 									_Stack.Pop();
 									_Stack.Push(vchHash);
 								}

--- a/NBitcoin/Stealth/BitcoinStealthAddress.cs
+++ b/NBitcoin/Stealth/BitcoinStealthAddress.cs
@@ -50,7 +50,7 @@ namespace NBitcoin.Stealth
 			if(rawform.Length < byteCount)
 				_Rawform = rawform.Concat(new byte[byteCount - rawform.Length]).ToArray();
 			if(rawform.Length > byteCount)
-				_Rawform = rawform.Take(byteCount).ToArray();
+				_Rawform = rawform.SafeSubarray(0, byteCount);
 
 			_Mask = new byte[byteCount];
 			int bitleft = bitcount;

--- a/NBitcoin/Target.cs
+++ b/NBitcoin/Target.cs
@@ -47,7 +47,7 @@ namespace NBitcoin
 			if(compact.Length == 4)
 			{
 				var exp = compact[0];
-				var val = compact.Skip(1).Take(3).Reverse().ToArray();
+				var val = compact.SafeSubarray(1, 3).Reverse().ToArray();
 				_Target = new BigInteger(val) << 8 * (exp - 3);
 			}
 			else
@@ -76,7 +76,7 @@ namespace NBitcoin
 		public static implicit operator uint(Target a)
 		{
 			var bytes = a._Target.ToByteArray().Reverse().ToArray();
-			var val = bytes.Take(3).Reverse().ToArray();
+			var val = bytes.SafeSubarray(0, Math.Min(bytes.Length,3)).Reverse().ToArray();
 			var exp = (byte)(bytes.Length);
 			var missing = 4 - val.Length;
 			if(missing > 0)

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -355,7 +355,7 @@ namespace NBitcoin
 								&& _Script[2] == 20 && _Script[23] == (byte)OpcodeType.OP_EQUALVERIFY
 								&& _Script[24] == (byte)OpcodeType.OP_CHECKSIG)
 			{
-				return new KeyId(_Script.Skip(3).Take(20).ToArray());
+				return new KeyId(_Script.SafeSubarray(3, 20));
 			}
 			return null;
 		}
@@ -365,7 +365,7 @@ namespace NBitcoin
 			if(_Script.Length == 23 && _Script[0] == (byte)OpcodeType.OP_HASH160 && _Script[1] == 20
 								&& _Script[22] == (byte)OpcodeType.OP_EQUAL)
 			{
-				return new ScriptId(_Script.Skip(2).Take(20).ToArray());
+				return new ScriptId(_Script.SafeSubarray(2, 20));
 			}
 			return null;
 		}
@@ -419,12 +419,12 @@ namespace NBitcoin
 			switch(nSize)
 			{
 				case 0x00:
-					return new Script(OpcodeType.OP_DUP, OpcodeType.OP_HASH160, Op.GetPushOp(data.Take(20).ToArray()), OpcodeType.OP_EQUALVERIFY, OpcodeType.OP_CHECKSIG);
+					return new Script(OpcodeType.OP_DUP, OpcodeType.OP_HASH160, Op.GetPushOp(data.SafeSubarray(0, 20)), OpcodeType.OP_EQUALVERIFY, OpcodeType.OP_CHECKSIG);
 				case 0x01:
-					return new Script(OpcodeType.OP_HASH160, Op.GetPushOp(data.Take(20).ToArray()), OpcodeType.OP_EQUAL);
+					return new Script(OpcodeType.OP_HASH160, Op.GetPushOp(data.SafeSubarray(0, 20)), OpcodeType.OP_EQUAL);
 				case 0x02:
 				case 0x03:
-					return new Script(Op.GetPushOp(new byte[] { (byte)nSize }.Concat(data.Take(32)).ToArray()), OpcodeType.OP_CHECKSIG);
+					return new Script(Op.GetPushOp(new byte[] { (byte)nSize }.Concat(data.SafeSubarray(0, 32)).ToArray()), OpcodeType.OP_CHECKSIG);
 				case 0x04:
 				case 0x05:
 					byte[] vch = new byte[33];

--- a/NBitcoin/Utils.cs
+++ b/NBitcoin/Utils.cs
@@ -92,7 +92,7 @@ namespace NBitcoin
 		}
 		public static IEnumerable<List<T>> Partition<T>(this IEnumerable<T> source, int max)
 		{
-			return Partition<T>(source, () => max);
+			return Partition(source, () => max);
 		}
 		public static IEnumerable<List<T>> Partition<T>(this IEnumerable<T> source, Func<int> max)
 		{
@@ -225,6 +225,37 @@ namespace NBitcoin
 			return (int)Math.Truncate((DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds);
 		}
 	}
+
+	internal static class ByteArrayExtensions
+	{
+		internal static byte[] SafeSubarray(this byte[] array, int offset, int count)
+		{
+			if(array == null)
+				throw new ArgumentNullException("array");
+			if(offset < 0 || offset > array.Length )
+				throw new ArgumentOutOfRangeException("offset");
+			if(count < 0 || offset + count > array.Length )
+				throw new ArgumentOutOfRangeException("count");
+
+			var data = new byte[count];
+			Buffer.BlockCopy(array, offset, data, 0, count);
+			return data;
+		}
+
+		internal static byte[] SafeSubarray(this byte[] array, int offset)
+		{
+			if (array == null)
+				throw new ArgumentNullException("array");
+			if (offset < 0 || offset > array.Length)
+				throw new ArgumentOutOfRangeException("offset");
+
+			var count = array.Length - offset;
+			var data = new byte[count];
+			Buffer.BlockCopy(array, offset, data, 0, count);
+			return data;
+		}
+	}
+
 	public class Utils
 	{
 		public static bool ArrayEqual(byte[] a, byte[] b)


### PR DESCRIPTION
@NicolasDorier this PR has a new method called SafeSubarray. It is used as follow:

Instead of:
```
var newByteArray = sourceByteArray.Skip(n).Take(count).ToArray();
```

we can use:
```
var newByteArray = sourceByteArray.SafeSubarray(n, count);
```
