### PR TITLE
fix for base58check encoder

### DIFF
--- a/NBitcoin.Tests/ConverterTests.cs
+++ b/NBitcoin.Tests/ConverterTests.cs
@@ -89,7 +89,6 @@ namespace NBitcoin.Tests
 
 			foreach(var test in tests)
 			{
-				var expected = Encoding.UTF8.GetBytes(test.Expected);
 				var input = Encoding.UTF8.GetBytes(test.Input);
 				var encoded = test.Encoder.EncodeData(input);
 				Assert.Equal(test.Expected, encoded);
@@ -103,6 +102,14 @@ namespace NBitcoin.Tests
 				{
 				}
 			}
+
+			var expectedText = "2189xoVGsHC6VbVPUrKeH3fhT429VDruzdgUJFk37PNskG";
+			var input1 = Encoding.UTF8.GetBytes("---é ^ç hello \"12345\"  wooorld---");
+			var encoded1 = Encoders.Base58Check.EncodeData(input1, 3, input1.Length-6);
+			Assert.Equal(expectedText, encoded1);
+
+			var decoded1 = Encoders.Base58Check.DecodeData(encoded1);
+			AssertEx.CollectionEquals(input1.SafeSubarray(3, input1.Length-6), decoded1);
 		}
 	}
 }

--- a/NBitcoin/DataEncoders/Base58Encoder.cs
+++ b/NBitcoin/DataEncoders/Base58Encoder.cs
@@ -17,20 +17,20 @@ namespace NBitcoin.DataEncoders
 				var hash = Hashes.Hash256(data, offset, count).ToBytes();
 				Buffer.BlockCopy(hash, 0, toEncode, count, 4);
 
-				return EncodeDataCore(toEncode, toEncode.Length);
+				return EncodeDataCore(toEncode, 0, toEncode.Length);
 			}
 
-			return EncodeDataCore(data, count);
+			return EncodeDataCore(data, offset, count);
 		}
 
-		private static string EncodeDataCore(byte[] data, int length)
+		private static string EncodeDataCore(byte[] data, int offset, int count)
 		{
 			BigInteger bn58 = 58;
 			BigInteger bn0 = 0;
 
 			// Convert big endian data to little endian
 			// Extra zero at the end make sure bignum will interpret as a positive number
-			byte[] vchTmp = data.Take(length).Reverse().Concat(new byte[] { 0x00 }).ToArray();
+			byte[] vchTmp = data.SafeSubarray(offset, count).Reverse().Concat(new byte[] { 0x00 }).ToArray();
 
 			// Convert little endian data to bignum
 			BigInteger bn = new BigInteger(vchTmp);
@@ -51,11 +51,11 @@ namespace NBitcoin.DataEncoders
 			}
 
 			// Leading zeroes encoded as base58 zeros
-			for(int i = 0 ; i < length && data[i] == 0 ; i++)
+			for (int i = offset; i < offset+count && data[i] == 0; i++)
 				str += pszBase58[0];
 
 			// Convert little endian std::string to big endian
-			str = new String(str.ToCharArray().Reverse().ToArray());
+			str = new String(str.Reverse().ToArray());
 			return str;
 		}
 
@@ -100,7 +100,7 @@ namespace NBitcoin.DataEncoders
 			BigInteger bn = 0;
 			BigInteger bnChar;
 			int i = 0;
-			while(DataEncoder.IsSpace(encoded[i]))
+			while(IsSpace(encoded[i]))
 			{
 				i++;
 				if(i >= encoded.Length)
@@ -112,7 +112,7 @@ namespace NBitcoin.DataEncoders
 				var p1 = pszBase58.IndexOf(encoded[y]);
 				if(p1 == -1)
 				{
-					while(DataEncoder.IsSpace(encoded[y]))
+					while(IsSpace(encoded[y]))
 					{
 						y++;
 						if(y >= encoded.Length)

--- a/NBitcoin/DataEncoders/Encoders.cs
+++ b/NBitcoin/DataEncoders/Encoders.cs
@@ -1,14 +1,29 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 
 namespace NBitcoin.DataEncoders
 {
 	public abstract class DataEncoder
 	{
-		public static readonly char[] SpaceCharacters = new[] { ' ', '\t', '\n', '\v', '\f', '\r' };
+		// char.IsWhiteSpace fits well but it match other whitespaces 
+		// characters too and also works for unicode characters.
 		public static bool IsSpace(char c)
 		{
-			return SpaceCharacters.Contains(c);
+			switch(c) {
+				case ' ':
+				case '\t':
+				case '\n':
+				case '\v':
+				case '\f':
+				case '\r':
+					return true;
+			}
+			return false;
+		}
+
+		internal DataEncoder()
+		{
 		}
 
 		public string EncodeData(byte[] data)
@@ -21,7 +36,7 @@ namespace NBitcoin.DataEncoders
 		public abstract byte[] DecodeData(string encoded);
 	}
 
-	public class Encoders
+	public static class Encoders
 	{
 		static readonly ASCIIEncoder _ASCII = new ASCIIEncoder();
 		public static DataEncoder ASCII


### PR DESCRIPTION
The following test fails:

```
[Fact]
public void encode_array_pattern()
{
   var expectedText = "2189xoVGsHC6VbVPUrKeH3fhT429VDruzdgUJFk37PNskG";
   var input1 = Encoding.UTF8.GetBytes("---é ^ç hello \"12345\"  wooorld---");
   var encoded1 = Encoders.Base58Check.EncodeData(input1, 3, input1.Length-6);
   Assert.Equal(expectedText, encoded1);
}
```