### PR TITLE
ParseJson & ParseHex

### DIFF
--- a/NBitcoin.Tests/ColoredCoinsTests.cs
+++ b/NBitcoin.Tests/ColoredCoinsTests.cs
@@ -29,7 +29,7 @@ namespace NBitcoin.Tests
 					var txObj = new Transaction(tx);
 					repository.Put(txObj.GetHash(), txObj);
 				}
-				TestedTxId = uint256.ParseHex(testcase.testedtx);
+				TestedTxId = uint256.Parse(testcase.testedtx);
 				Repository = new NoSqlColoredTransactionRepository(repository, new InMemoryNoSqlRepository());
 			}
 
@@ -119,9 +119,9 @@ namespace NBitcoin.Tests
 		public void TestFun()
 		{
 			var repo = new NoSqlColoredTransactionRepository(new BlockrTransactionRepository());
-			var colored = ColoredTransaction.FetchColors(uint256.ParseHex("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"), repo);
+			var colored = ColoredTransaction.FetchColors(uint256.Parse("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"), repo);
 
-			var prismColored = new CoinprismColoredTransactionRepository().Get(uint256.ParseHex("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"));
+			var prismColored = new CoinprismColoredTransactionRepository().Get(uint256.Parse("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"));
 
 			Assert.True(colored.ToBytes().SequenceEqual(prismColored.ToBytes()));
 		}
@@ -287,7 +287,7 @@ namespace NBitcoin.Tests
 		{
 			CanFetchTransactionFromCoinprismCore("CanColorizeIssuanceTransaction");
 			CanFetchTransactionFromCoinprismCore("CanColorizeTransferTransaction");
-			Assert.Null(new CoinprismColoredTransactionRepository().Get(uint256.ParseHex("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a5")));
+			Assert.Null(new CoinprismColoredTransactionRepository().Get(uint256.Parse("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a5")));
 		}
 
 		private void CanFetchTransactionFromCoinprismCore(string test)

--- a/NBitcoin.Tests/ColoredCoinsTests.cs
+++ b/NBitcoin.Tests/ColoredCoinsTests.cs
@@ -29,7 +29,7 @@ namespace NBitcoin.Tests
 					var txObj = new Transaction(tx);
 					repository.Put(txObj.GetHash(), txObj);
 				}
-				TestedTxId = new uint256(testcase.testedtx);
+				TestedTxId = uint256.ParseHex(testcase.testedtx);
 				Repository = new NoSqlColoredTransactionRepository(repository, new InMemoryNoSqlRepository());
 			}
 
@@ -119,9 +119,9 @@ namespace NBitcoin.Tests
 		public void TestFun()
 		{
 			var repo = new NoSqlColoredTransactionRepository(new BlockrTransactionRepository());
-			var colored = ColoredTransaction.FetchColors(new uint256("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"), repo);
+			var colored = ColoredTransaction.FetchColors(uint256.ParseHex("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"), repo);
 
-			var prismColored = new CoinprismColoredTransactionRepository().Get(new uint256("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"));
+			var prismColored = new CoinprismColoredTransactionRepository().Get(uint256.ParseHex("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a6"));
 
 			Assert.True(colored.ToBytes().SequenceEqual(prismColored.ToBytes()));
 		}
@@ -287,7 +287,7 @@ namespace NBitcoin.Tests
 		{
 			CanFetchTransactionFromCoinprismCore("CanColorizeIssuanceTransaction");
 			CanFetchTransactionFromCoinprismCore("CanColorizeTransferTransaction");
-			Assert.Null(new CoinprismColoredTransactionRepository().Get(new uint256("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a5")));
+			Assert.Null(new CoinprismColoredTransactionRepository().Get(uint256.ParseHex("b4399a545c4ddd640920d63af75e7367fe4d94b2d7f7a3423105e25ac5f165a5")));
 		}
 
 		private void CanFetchTransactionFromCoinprismCore(string test)

--- a/NBitcoin.Tests/MnemonicReference_tests.cs
+++ b/NBitcoin.Tests/MnemonicReference_tests.cs
@@ -53,10 +53,10 @@ namespace NBitcoin.Tests
 				node.VersionHandshake();
 				using(var listener = node.CreateListener())
 				{
-					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_BLOCK, new uint256(" 000000000000000001d6ec8218c6fdb1a757855238543e05def13a363b8ff95e"))));
+					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_BLOCK, uint256.ParseHex(" 000000000000000001d6ec8218c6fdb1a757855238543e05def13a363b8ff95e"))));
 					var payload = listener.ReceivePayload<BlockPayload>();
 					var block = payload.Object;
-					var tx = block.Transactions.First(t => t.GetHash() == new uint256("d1bc46420e21e0f7b059c04a851f3558669c67ea0dd1441836abc37413e1857d"));
+					var tx = block.Transactions.First(t => t.GetHash() == uint256.ParseHex("d1bc46420e21e0f7b059c04a851f3558669c67ea0dd1441836abc37413e1857d"));
 					//http://www.xbt.hk/cgi-bin/ma1.pl?txid=4a85f6cc29aca334c1a78c5db74b492b741e67958aee59ff827c4c0862f4fbc1&txo=2&mincs=20
 					//http://www.xbt.hk/cgi-bin/ma1.pl?txid=e05e5f4c81fd63eb92b3a4ee963c06176a0db3da092ee357be668e4f0ae68333&txo=5&mincs=20
 					//http://www.xbt.hk/cgi-bin/ma1.pl?txid=d1bc46420e21e0f7b059c04a851f3558669c67ea0dd1441836abc37413e1857d&txo=1&mincs=20

--- a/NBitcoin.Tests/MnemonicReference_tests.cs
+++ b/NBitcoin.Tests/MnemonicReference_tests.cs
@@ -53,10 +53,10 @@ namespace NBitcoin.Tests
 				node.VersionHandshake();
 				using(var listener = node.CreateListener())
 				{
-					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_BLOCK, uint256.ParseHex(" 000000000000000001d6ec8218c6fdb1a757855238543e05def13a363b8ff95e"))));
+					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_BLOCK, uint256.Parse(" 000000000000000001d6ec8218c6fdb1a757855238543e05def13a363b8ff95e"))));
 					var payload = listener.ReceivePayload<BlockPayload>();
 					var block = payload.Object;
-					var tx = block.Transactions.First(t => t.GetHash() == uint256.ParseHex("d1bc46420e21e0f7b059c04a851f3558669c67ea0dd1441836abc37413e1857d"));
+					var tx = block.Transactions.First(t => t.GetHash() == uint256.Parse("d1bc46420e21e0f7b059c04a851f3558669c67ea0dd1441836abc37413e1857d"));
 					//http://www.xbt.hk/cgi-bin/ma1.pl?txid=4a85f6cc29aca334c1a78c5db74b492b741e67958aee59ff827c4c0862f4fbc1&txo=2&mincs=20
 					//http://www.xbt.hk/cgi-bin/ma1.pl?txid=e05e5f4c81fd63eb92b3a4ee963c06176a0db3da092ee357be668e4f0ae68333&txo=5&mincs=20
 					//http://www.xbt.hk/cgi-bin/ma1.pl?txid=d1bc46420e21e0f7b059c04a851f3558669c67ea0dd1441836abc37413e1857d&txo=1&mincs=20

--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -192,8 +192,8 @@ namespace NBitcoin.Tests
 		{
 			using(var node = Node.ConnectToLocal(Network.TestNet, isRelay: false))
 			{
-				var knownBlock = uint256.ParseHex("00000000db9a24016f87f98ddaf08d32383319431d27c37dee2c91898ef57066");
-				var knownTx = uint256.ParseHex("dabf4960a5c6d9affec746734cbd8ba68287126b8c4514de846a9702a813a449");
+				var knownBlock = uint256.Parse("00000000db9a24016f87f98ddaf08d32383319431d27c37dee2c91898ef57066");
+				var knownTx = uint256.Parse("dabf4960a5c6d9affec746734cbd8ba68287126b8c4514de846a9702a813a449");
 				node.VersionHandshake();
 				using(var list = node.CreateListener()
 										.Where(m => m.Message.Payload is MerkleBlockPayload || m.Message.Payload is TxPayload))
@@ -204,7 +204,7 @@ namespace NBitcoin.Tests
 					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_FILTERED_BLOCK, knownBlock)));
 					var merkle = list.ReceivePayload<MerkleBlockPayload>();
 					var tree = merkle.Object.PartialMerkleTree;
-					Assert.True(tree.Check(uint256.ParseHex("89b905cdf2ab70c1acd9b538cf6738937ae28fca86c1514ebbf130962312e478")));
+					Assert.True(tree.Check(uint256.Parse("89b905cdf2ab70c1acd9b538cf6738937ae28fca86c1514ebbf130962312e478")));
 					Assert.True(tree.GetMatchedTransactions().Count() > 1);
 					Assert.True(tree.GetMatchedTransactions().Contains(knownTx));
 
@@ -229,7 +229,7 @@ namespace NBitcoin.Tests
 					filter = filter.Clone();
 					act();
 
-					var unknownBlock = uint256.ParseHex("00000000ad262227291eaf90cafdc56a8f8451e2d7653843122c5bb0bf2dfcdd");
+					var unknownBlock = uint256.Parse("00000000ad262227291eaf90cafdc56a8f8451e2d7653843122c5bb0bf2dfcdd");
 					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_FILTERED_BLOCK, Network.TestNet.GetGenesis().GetHash())));
 
 					merkle = list.ReceivePayload<MerkleBlockPayload>();
@@ -257,7 +257,7 @@ namespace NBitcoin.Tests
 		{
 			using(var node = Node.ConnectToLocal(Network.TestNet))
 			{
-				var chain = node.GetChain(uint256.ParseHex("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
+				var chain = node.GetChain(uint256.Parse("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
 				Assert.True(chain.Height == 500);
 				using(var tester = new NodeServerTester(Network.TestNet))
 				{
@@ -273,11 +273,11 @@ namespace NBitcoin.Tests
 					var behavior = new ChainBehavior(new ConcurrentChain(Network.TestNet));
 					n2.Behaviors.Add(behavior);
 					TestUtils.Eventually(() => behavior.Chain.Height == 500);
-					var chain2 = n2.GetChain(uint256.ParseHex("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
+					var chain2 = n2.GetChain(uint256.Parse("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
 					Assert.True(chain2.Height == 500);
-					var chain1 = n1.GetChain(uint256.ParseHex("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
+					var chain1 = n1.GetChain(uint256.Parse("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
 					Assert.True(chain1.Height == 500);
-					chain1 = n1.GetChain(uint256.ParseHex("000000008cd4b1bdaa1278e3f1708258f862da16858324e939dc650627cd2e27"));
+					chain1 = n1.GetChain(uint256.Parse("000000008cd4b1bdaa1278e3f1708258f862da16858324e939dc650627cd2e27"));
 					Assert.True(chain1.Height == 499);
 					Thread.Sleep(5000);
 				}
@@ -302,7 +302,7 @@ namespace NBitcoin.Tests
 			using(var node = Node.ConnectToLocal(Network.TestNet))
 			{
 				node.VersionHandshake();
-				var stop = uint256.ParseHex("0000000000005e5fd51f764d230441092f1b69d1a1eeab334c5bb32412e8dc51");
+				var stop = uint256.Parse("0000000000005e5fd51f764d230441092f1b69d1a1eeab334c5bb32412e8dc51");
 				Random rand = new Random();
 				var chains =
 					Enumerable.Range(0, 5)
@@ -505,7 +505,7 @@ namespace NBitcoin.Tests
 			Assert.True(reject.Code == RejectCode.DUPLICATE);
 			Assert.True(reject.CodeType == RejectCodeType.Transaction);
 			Assert.True(reject.Reason == "bad-txns-inputs-spent");
-			Assert.True(reject.Hash == uint256.ParseHex("964182ffbcec5fafd8f33594b17d6aad4937ff1c59f699e91af44fda94967a57"));
+			Assert.True(reject.Hash == uint256.Parse("964182ffbcec5fafd8f33594b17d6aad4937ff1c59f699e91af44fda94967a57"));
 		}
 
 		[Fact]
@@ -517,7 +517,7 @@ namespace NBitcoin.Tests
 				node.VersionHandshake();
 				node.SendMessageAsync(new GetDataPayload(new InventoryVector()
 						{
-							Hash = uint256.ParseHex("00000000278d16a190be56f541b3fda44c3168b43dcc05d9c664e6f27ffe2c78"),
+							Hash = uint256.Parse("00000000278d16a190be56f541b3fda44c3168b43dcc05d9c664e6f27ffe2c78"),
 							Type = InventoryType.MSG_BLOCK
 						}));
 

--- a/NBitcoin.Tests/ProtocolTests.cs
+++ b/NBitcoin.Tests/ProtocolTests.cs
@@ -192,8 +192,8 @@ namespace NBitcoin.Tests
 		{
 			using(var node = Node.ConnectToLocal(Network.TestNet, isRelay: false))
 			{
-				var knownBlock = new uint256("00000000db9a24016f87f98ddaf08d32383319431d27c37dee2c91898ef57066");
-				var knownTx = new uint256("dabf4960a5c6d9affec746734cbd8ba68287126b8c4514de846a9702a813a449");
+				var knownBlock = uint256.ParseHex("00000000db9a24016f87f98ddaf08d32383319431d27c37dee2c91898ef57066");
+				var knownTx = uint256.ParseHex("dabf4960a5c6d9affec746734cbd8ba68287126b8c4514de846a9702a813a449");
 				node.VersionHandshake();
 				using(var list = node.CreateListener()
 										.Where(m => m.Message.Payload is MerkleBlockPayload || m.Message.Payload is TxPayload))
@@ -204,7 +204,7 @@ namespace NBitcoin.Tests
 					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_FILTERED_BLOCK, knownBlock)));
 					var merkle = list.ReceivePayload<MerkleBlockPayload>();
 					var tree = merkle.Object.PartialMerkleTree;
-					Assert.True(tree.Check(new uint256("89b905cdf2ab70c1acd9b538cf6738937ae28fca86c1514ebbf130962312e478")));
+					Assert.True(tree.Check(uint256.ParseHex("89b905cdf2ab70c1acd9b538cf6738937ae28fca86c1514ebbf130962312e478")));
 					Assert.True(tree.GetMatchedTransactions().Count() > 1);
 					Assert.True(tree.GetMatchedTransactions().Contains(knownTx));
 
@@ -229,7 +229,7 @@ namespace NBitcoin.Tests
 					filter = filter.Clone();
 					act();
 
-					var unknownBlock = new uint256("00000000ad262227291eaf90cafdc56a8f8451e2d7653843122c5bb0bf2dfcdd");
+					var unknownBlock = uint256.ParseHex("00000000ad262227291eaf90cafdc56a8f8451e2d7653843122c5bb0bf2dfcdd");
 					node.SendMessageAsync(new GetDataPayload(new InventoryVector(InventoryType.MSG_FILTERED_BLOCK, Network.TestNet.GetGenesis().GetHash())));
 
 					merkle = list.ReceivePayload<MerkleBlockPayload>();
@@ -257,7 +257,7 @@ namespace NBitcoin.Tests
 		{
 			using(var node = Node.ConnectToLocal(Network.TestNet))
 			{
-				var chain = node.GetChain(new uint256("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
+				var chain = node.GetChain(uint256.ParseHex("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
 				Assert.True(chain.Height == 500);
 				using(var tester = new NodeServerTester(Network.TestNet))
 				{
@@ -273,11 +273,11 @@ namespace NBitcoin.Tests
 					var behavior = new ChainBehavior(new ConcurrentChain(Network.TestNet));
 					n2.Behaviors.Add(behavior);
 					TestUtils.Eventually(() => behavior.Chain.Height == 500);
-					var chain2 = n2.GetChain(new uint256("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
+					var chain2 = n2.GetChain(uint256.ParseHex("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
 					Assert.True(chain2.Height == 500);
-					var chain1 = n1.GetChain(new uint256("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
+					var chain1 = n1.GetChain(uint256.ParseHex("00000000a2424460c992803ed44cfe0c0333e91af04fde9a6a97b468bf1b5f70"));
 					Assert.True(chain1.Height == 500);
-					chain1 = n1.GetChain(new uint256("000000008cd4b1bdaa1278e3f1708258f862da16858324e939dc650627cd2e27"));
+					chain1 = n1.GetChain(uint256.ParseHex("000000008cd4b1bdaa1278e3f1708258f862da16858324e939dc650627cd2e27"));
 					Assert.True(chain1.Height == 499);
 					Thread.Sleep(5000);
 				}
@@ -302,7 +302,7 @@ namespace NBitcoin.Tests
 			using(var node = Node.ConnectToLocal(Network.TestNet))
 			{
 				node.VersionHandshake();
-				var stop = new uint256("0000000000005e5fd51f764d230441092f1b69d1a1eeab334c5bb32412e8dc51");
+				var stop = uint256.ParseHex("0000000000005e5fd51f764d230441092f1b69d1a1eeab334c5bb32412e8dc51");
 				Random rand = new Random();
 				var chains =
 					Enumerable.Range(0, 5)
@@ -505,7 +505,7 @@ namespace NBitcoin.Tests
 			Assert.True(reject.Code == RejectCode.DUPLICATE);
 			Assert.True(reject.CodeType == RejectCodeType.Transaction);
 			Assert.True(reject.Reason == "bad-txns-inputs-spent");
-			Assert.True(reject.Hash == new uint256("964182ffbcec5fafd8f33594b17d6aad4937ff1c59f699e91af44fda94967a57"));
+			Assert.True(reject.Hash == uint256.ParseHex("964182ffbcec5fafd8f33594b17d6aad4937ff1c59f699e91af44fda94967a57"));
 		}
 
 		[Fact]
@@ -517,7 +517,7 @@ namespace NBitcoin.Tests
 				node.VersionHandshake();
 				node.SendMessageAsync(new GetDataPayload(new InventoryVector()
 						{
-							Hash = new uint256("00000000278d16a190be56f541b3fda44c3168b43dcc05d9c664e6f27ffe2c78"),
+							Hash = uint256.ParseHex("00000000278d16a190be56f541b3fda44c3168b43dcc05d9c664e6f27ffe2c78"),
 							Type = InventoryType.MSG_BLOCK
 						}));
 

--- a/NBitcoin.Tests/RepositoryTests.cs
+++ b/NBitcoin.Tests/RepositoryTests.cs
@@ -134,9 +134,9 @@ namespace NBitcoin.Tests
 			{
 				index.Put(block.Item);
 			}
-			var genesis = index.Get(new uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
+			var genesis = index.Get(uint256.ParseHex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
 			Assert.NotNull(genesis);
-			var invalidBlock = index.Get(new uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26e"));
+			var invalidBlock = index.Get(uint256.ParseHex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26e"));
 			Assert.Null(invalidBlock);
 		}
 

--- a/NBitcoin.Tests/RepositoryTests.cs
+++ b/NBitcoin.Tests/RepositoryTests.cs
@@ -134,9 +134,9 @@ namespace NBitcoin.Tests
 			{
 				index.Put(block.Item);
 			}
-			var genesis = index.Get(uint256.ParseHex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
+			var genesis = index.Get(uint256.Parse("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
 			Assert.NotNull(genesis);
-			var invalidBlock = index.Get(uint256.ParseHex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26e"));
+			var invalidBlock = index.Get(uint256.Parse("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26e"));
 			Assert.Null(invalidBlock);
 		}
 

--- a/NBitcoin.Tests/bip32_tests.cs
+++ b/NBitcoin.Tests/bip32_tests.cs
@@ -144,7 +144,7 @@ namespace NBitcoin.Tests
 		[Trait("UnitTest", "UnitTest")]
 		public void CanUseKeyPath()
 		{
-			var keyPath = new KeyPath("0/1/2/3");
+			var keyPath = KeyPath.Parse("0/1/2/3");
 			Assert.Equal(keyPath.ToString(), "0/1/2/3");
 			var key = new ExtKey();
 			Assert.Equal(key
@@ -167,16 +167,16 @@ namespace NBitcoin.Tests
 			keyPath = new KeyPath(new uint[] { 0x8000002Cu, 1u });
 			Assert.Equal(keyPath.ToString(), "44'/1");
 
-			keyPath = new KeyPath("44'/1");
+			keyPath = KeyPath.Parse("44'/1");
 			Assert.False(keyPath.IsHardened);
-			Assert.True(new KeyPath("44'/1'").IsHardened);
+			Assert.True(KeyPath.Parse("44'/1'").IsHardened);
 			Assert.Equal(keyPath[0], 0x8000002Cu);
 			Assert.Equal(keyPath[1], 1u);
 
 			key = new ExtKey();
 			Assert.Equal(key.Derive(keyPath).ToString(Network.Main), key.Derive(44, true).Derive(1, false).ToString(Network.Main));
 
-			keyPath = new KeyPath("");
+			keyPath = KeyPath.Parse("");
 			keyPath = keyPath.Derive(44, true).Derive(1, false);
 			Assert.Equal(keyPath.ToString(), "44'/1");
 			Assert.Equal(key.Derive(keyPath).ToString(Network.Main), key.Derive(44, true).Derive(1, false).ToString(Network.Main));

--- a/NBitcoin.Tests/bloom_tests.cs
+++ b/NBitcoin.Tests/bloom_tests.cs
@@ -109,7 +109,7 @@ namespace NBitcoin.Tests
 			spendingTx.ReadWrite(vch);
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(uint256.ParseHex("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
+			filter.Insert(uint256.Parse("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match tx hash");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
@@ -135,11 +135,11 @@ namespace NBitcoin.Tests
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match output address");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new OutPoint(uint256.ParseHex("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+			filter.Insert(new OutPoint(uint256.Parse("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match COutPoint");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			OutPoint prevOutPoint = new OutPoint(uint256.ParseHex("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
+			OutPoint prevOutPoint = new OutPoint(uint256.Parse("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
 			{
 				var data = prevOutPoint.ToBytes();
 				filter.Insert(data);
@@ -147,7 +147,7 @@ namespace NBitcoin.Tests
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match manually serialized COutPoint");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(uint256.ParseHex("00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"));
+			filter.Insert(uint256.Parse("00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"));
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random tx hash");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
@@ -155,11 +155,11 @@ namespace NBitcoin.Tests
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random address");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new OutPoint(uint256.ParseHex("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 1));
+			filter.Insert(new OutPoint(uint256.Parse("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 1));
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new OutPoint(uint256.ParseHex("0x000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+			filter.Insert(new OutPoint(uint256.Parse("0x000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 		}
 
@@ -175,7 +175,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the last transaction
-			filter.Insert(uint256.ParseHex("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+			filter.Insert(uint256.Parse("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
 
 			MerkleBlock merkleBlock = block.Filter(filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -187,7 +187,7 @@ namespace NBitcoin.Tests
 			AssertMatch(block, vMatchedTxn, "0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20", 0, 8);
 
 			// Also match the 8th transaction
-			filter.Insert(uint256.ParseHex("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
+			filter.Insert(uint256.Parse("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
 			merkleBlock = block.Filter(filter);
 			vMatchedTxn = merkleBlock.PartialMerkleTree.GetMatchedTransactions().ToList();
 			Assert.True(merkleBlock.PartialMerkleTree.Check(block.Header.HashMerkleRoot));
@@ -203,7 +203,7 @@ namespace NBitcoin.Tests
 
 		private void AssertMatch(Block block, List<uint256> vMatchedTxn, string txId, int expectedMerkleIndex, int expectedTxIndex)
 		{
-			var id = uint256.ParseHex(txId);
+			var id = uint256.Parse(txId);
 			Assert.True(vMatchedTxn[expectedMerkleIndex] == id);
 			var actualIndexTx = Array.IndexOf(block.Transactions.Select(t => t.GetHash()).ToArray(), id);
 			Assert.True(actualIndexTx == expectedTxIndex);
@@ -220,7 +220,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the first transaction
-			filter.Insert(uint256.ParseHex("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+			filter.Insert(uint256.Parse("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -261,7 +261,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_NONE);
 			// Match the first transaction
-			filter.Insert(uint256.ParseHex("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+			filter.Insert(uint256.Parse("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -305,7 +305,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the only transaction
-			filter.Insert(uint256.ParseHex("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
+			filter.Insert(uint256.Parse("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -333,7 +333,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the last transaction
-			filter.Insert(uint256.ParseHex("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
+			filter.Insert(uint256.Parse("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -344,7 +344,7 @@ namespace NBitcoin.Tests
 			AssertMatch(block, vMatchedTxn, "0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154", 0, 6);
 
 			// Also match the 4th transaction
-			filter.Insert(uint256.ParseHex("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
+			filter.Insert(uint256.Parse("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
 			merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.PartialMerkleTree.Check(block.Header.HashMerkleRoot));
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -377,9 +377,9 @@ namespace NBitcoin.Tests
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
 
 			// We should match the generation outpoint
-			Assert.True(filter.Contains(new OutPoint(uint256.ParseHex("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+			Assert.True(filter.Contains(new OutPoint(uint256.Parse("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
 			// ... but not the 4th transaction's output (its not pay-2-pubkey)
-			Assert.True(!filter.Contains(new OutPoint(uint256.ParseHex("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
+			Assert.True(!filter.Contains(new OutPoint(uint256.Parse("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
 		}
 
 
@@ -402,8 +402,8 @@ namespace NBitcoin.Tests
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
 
 			// We shouldn't match any outpoints (UPDATE_NONE)
-			Assert.True(!filter.Contains(new OutPoint(uint256.ParseHex("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
-			Assert.True(!filter.Contains((new OutPoint(uint256.ParseHex("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0))));
+			Assert.True(!filter.Contains(new OutPoint(uint256.Parse("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+			Assert.True(!filter.Contains((new OutPoint(uint256.Parse("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0))));
 		}
 	}
 }

--- a/NBitcoin.Tests/bloom_tests.cs
+++ b/NBitcoin.Tests/bloom_tests.cs
@@ -109,7 +109,7 @@ namespace NBitcoin.Tests
 			spendingTx.ReadWrite(vch);
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new uint256("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
+			filter.Insert(uint256.ParseHex("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match tx hash");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
@@ -135,11 +135,11 @@ namespace NBitcoin.Tests
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match output address");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new OutPoint(new uint256("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+			filter.Insert(new OutPoint(uint256.ParseHex("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match COutPoint");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			OutPoint prevOutPoint = new OutPoint(new uint256("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
+			OutPoint prevOutPoint = new OutPoint(uint256.ParseHex("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0);
 			{
 				var data = prevOutPoint.ToBytes();
 				filter.Insert(data);
@@ -147,7 +147,7 @@ namespace NBitcoin.Tests
 			Assert.True(filter.IsRelevantAndUpdate(tx), "Simple Bloom filter didn't match manually serialized COutPoint");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new uint256("00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"));
+			filter.Insert(uint256.ParseHex("00000009e784f32f62ef849763d4f45b98e07ba658647343b915ff832b110436"));
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random tx hash");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
@@ -155,11 +155,11 @@ namespace NBitcoin.Tests
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched random address");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new OutPoint(new uint256("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 1));
+			filter.Insert(new OutPoint(uint256.ParseHex("0x90c122d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 1));
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 
 			filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
-			filter.Insert(new OutPoint(new uint256("0x000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
+			filter.Insert(new OutPoint(uint256.ParseHex("0x000000d70786e899529d71dbeba91ba216982fb6ba58f3bdaab65e73b7e9260b"), 0));
 			Assert.True(!filter.IsRelevantAndUpdate(tx), "Simple Bloom filter matched COutPoint for an output we didn't care about");
 		}
 
@@ -175,7 +175,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the last transaction
-			filter.Insert(new uint256("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
+			filter.Insert(uint256.ParseHex("0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20"));
 
 			MerkleBlock merkleBlock = block.Filter(filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -187,7 +187,7 @@ namespace NBitcoin.Tests
 			AssertMatch(block, vMatchedTxn, "0x74d681e0e03bafa802c8aa084379aa98d9fcd632ddc2ed9782b586ec87451f20", 0, 8);
 
 			// Also match the 8th transaction
-			filter.Insert(new uint256("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
+			filter.Insert(uint256.ParseHex("0xdd1fd2a6fc16404faf339881a90adbde7f4f728691ac62e8f168809cdfae1053"));
 			merkleBlock = block.Filter(filter);
 			vMatchedTxn = merkleBlock.PartialMerkleTree.GetMatchedTransactions().ToList();
 			Assert.True(merkleBlock.PartialMerkleTree.Check(block.Header.HashMerkleRoot));
@@ -203,7 +203,7 @@ namespace NBitcoin.Tests
 
 		private void AssertMatch(Block block, List<uint256> vMatchedTxn, string txId, int expectedMerkleIndex, int expectedTxIndex)
 		{
-			var id = new uint256(txId);
+			var id = uint256.ParseHex(txId);
 			Assert.True(vMatchedTxn[expectedMerkleIndex] == id);
 			var actualIndexTx = Array.IndexOf(block.Transactions.Select(t => t.GetHash()).ToArray(), id);
 			Assert.True(actualIndexTx == expectedTxIndex);
@@ -220,7 +220,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the first transaction
-			filter.Insert(new uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+			filter.Insert(uint256.ParseHex("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -261,7 +261,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_NONE);
 			// Match the first transaction
-			filter.Insert(new uint256("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
+			filter.Insert(uint256.ParseHex("0xe980fe9f792d014e73b95203dc1335c5f9ce19ac537a419e6df5b47aecb93b70"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -305,7 +305,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the only transaction
-			filter.Insert(new uint256("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
+			filter.Insert(uint256.ParseHex("0x63194f18be0af63f2c6bc9dc0f777cbefed3d9415c4af83f3ee3a3d669c00cb5"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -333,7 +333,7 @@ namespace NBitcoin.Tests
 
 			BloomFilter filter = new BloomFilter(10, 0.000001, 0, BloomFlags.UPDATE_ALL);
 			// Match the last transaction
-			filter.Insert(new uint256("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
+			filter.Insert(uint256.ParseHex("0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154"));
 
 			MerkleBlock merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -344,7 +344,7 @@ namespace NBitcoin.Tests
 			AssertMatch(block, vMatchedTxn, "0x0a2a92f0bda4727d0a13eaddf4dd9ac6b5c61a1429e6b2b818f19b15df0ac154", 0, 6);
 
 			// Also match the 4th transaction
-			filter.Insert(new uint256("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
+			filter.Insert(uint256.ParseHex("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"));
 			merkleBlock = new MerkleBlock(block, filter);
 			Assert.True(merkleBlock.PartialMerkleTree.Check(block.Header.HashMerkleRoot));
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
@@ -377,9 +377,9 @@ namespace NBitcoin.Tests
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
 
 			// We should match the generation outpoint
-			Assert.True(filter.Contains(new OutPoint(new uint256("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+			Assert.True(filter.Contains(new OutPoint(uint256.ParseHex("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
 			// ... but not the 4th transaction's output (its not pay-2-pubkey)
-			Assert.True(!filter.Contains(new OutPoint(new uint256("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
+			Assert.True(!filter.Contains(new OutPoint(uint256.ParseHex("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0)));
 		}
 
 
@@ -402,9 +402,8 @@ namespace NBitcoin.Tests
 			Assert.True(merkleBlock.Header.GetHash() == block.GetHash());
 
 			// We shouldn't match any outpoints (UPDATE_NONE)
-			Assert.True(!filter.Contains(new OutPoint(new uint256("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
-			Assert.True(!filter.Contains((new OutPoint(new uint256("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0))));
+			Assert.True(!filter.Contains(new OutPoint(uint256.ParseHex("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
+			Assert.True(!filter.Contains((new OutPoint(uint256.ParseHex("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0))));
 		}
 	}
-
 }

--- a/NBitcoin.Tests/hash_tests.cs
+++ b/NBitcoin.Tests/hash_tests.cs
@@ -46,7 +46,7 @@ namespace NBitcoin.Tests
 		[Trait("UnitTest", "UnitTest")]
 		public void hash256()
 		{
-			Assert.Equal(new uint256("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), Network.Main.GetGenesis().GetHash());
+			Assert.Equal(uint256.ParseHex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), Network.Main.GetGenesis().GetHash());
 		}
 
 		[Fact]

--- a/NBitcoin.Tests/hash_tests.cs
+++ b/NBitcoin.Tests/hash_tests.cs
@@ -46,7 +46,7 @@ namespace NBitcoin.Tests
 		[Trait("UnitTest", "UnitTest")]
 		public void hash256()
 		{
-			Assert.Equal(uint256.ParseHex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), Network.Main.GetGenesis().GetHash());
+			Assert.Equal(uint256.Parse("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"), Network.Main.GetGenesis().GetHash());
 		}
 
 		[Fact]

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -1104,7 +1104,7 @@ namespace NBitcoin.Tests
 				{
 					var actualVIn = tx.Inputs[i];
 					var expectedVIn = test.JSON.@in[i];
-					Assert.Equal(new uint256((string)expectedVIn.prev_out.hash), actualVIn.PrevOut.Hash);
+					Assert.Equal(uint256.ParseHex((string)expectedVIn.prev_out.hash), actualVIn.PrevOut.Hash);
 					Assert.Equal((uint)expectedVIn.prev_out.n, actualVIn.PrevOut.N);
 					if(expectedVIn.sequence != null)
 						Assert.Equal((uint)expectedVIn.sequence, actualVIn.Sequence);
@@ -1153,7 +1153,7 @@ namespace NBitcoin.Tests
 				Dictionary<OutPoint, Script> mapprevOutScriptPubKeys = new Dictionary<OutPoint, Script>();
 				foreach(var vinput in inputs)
 				{
-					mapprevOutScriptPubKeys[new OutPoint(new uint256(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
+					mapprevOutScriptPubKeys[new OutPoint(uint256.ParseHex(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
 				}
 
 				Transaction tx = new Transaction((string)test[1]);
@@ -1237,7 +1237,7 @@ namespace NBitcoin.Tests
 				Dictionary<OutPoint, Script> mapprevOutScriptPubKeys = new Dictionary<OutPoint, Script>();
 				foreach(var vinput in inputs)
 				{
-					mapprevOutScriptPubKeys[new OutPoint(new uint256(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
+					mapprevOutScriptPubKeys[new OutPoint(uint256.ParseHex(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
 				}
 
 				Transaction tx = new Transaction((string)test[1]);

--- a/NBitcoin.Tests/transaction_tests.cs
+++ b/NBitcoin.Tests/transaction_tests.cs
@@ -1104,7 +1104,7 @@ namespace NBitcoin.Tests
 				{
 					var actualVIn = tx.Inputs[i];
 					var expectedVIn = test.JSON.@in[i];
-					Assert.Equal(uint256.ParseHex((string)expectedVIn.prev_out.hash), actualVIn.PrevOut.Hash);
+					Assert.Equal(uint256.Parse((string)expectedVIn.prev_out.hash), actualVIn.PrevOut.Hash);
 					Assert.Equal((uint)expectedVIn.prev_out.n, actualVIn.PrevOut.N);
 					if(expectedVIn.sequence != null)
 						Assert.Equal((uint)expectedVIn.sequence, actualVIn.Sequence);
@@ -1153,7 +1153,7 @@ namespace NBitcoin.Tests
 				Dictionary<OutPoint, Script> mapprevOutScriptPubKeys = new Dictionary<OutPoint, Script>();
 				foreach(var vinput in inputs)
 				{
-					mapprevOutScriptPubKeys[new OutPoint(uint256.ParseHex(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
+					mapprevOutScriptPubKeys[new OutPoint(uint256.Parse(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
 				}
 
 				Transaction tx = new Transaction((string)test[1]);
@@ -1237,7 +1237,7 @@ namespace NBitcoin.Tests
 				Dictionary<OutPoint, Script> mapprevOutScriptPubKeys = new Dictionary<OutPoint, Script>();
 				foreach(var vinput in inputs)
 				{
-					mapprevOutScriptPubKeys[new OutPoint(uint256.ParseHex(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
+					mapprevOutScriptPubKeys[new OutPoint(uint256.Parse(vinput[0].ToString()), int.Parse(vinput[1].ToString()))] = script_tests.ParseScript(vinput[2].ToString());
 				}
 
 				Transaction tx = new Transaction((string)test[1]);

--- a/NBitcoin.Tests/uint256_tests.cs
+++ b/NBitcoin.Tests/uint256_tests.cs
@@ -271,7 +271,7 @@ namespace NBitcoin.Tests
 		public void plusMinus()
 		{
 			uint256 TmpL = 0;
-			Assert.True(R1L + R2L == uint256.ParseHex(R1LplusR2L));
+			Assert.True(R1L + R2L == uint256.Parse(R1LplusR2L));
 			TmpL += R1L;
 			Assert.True(TmpL == R1L);
 			TmpL += R2L;
@@ -319,7 +319,7 @@ namespace NBitcoin.Tests
 
 			// 160-bit; copy-pasted
 			uint160 TmpS = 0;
-			Assert.True(R1S + R2S == uint160.ParseHex(R1LplusR2L));
+			Assert.True(R1S + R2S == uint160.Parse(R1LplusR2L));
 			TmpS += R1S;
 			Assert.True(TmpS == R1S);
 			TmpS += R2S;
@@ -605,30 +605,30 @@ namespace NBitcoin.Tests
 			}
 			Assert.True(ZeroS == (OneS << 256));
 
-			Assert.True(uint256.ParseHex("0x" + R1L.ToString()) == R1L);
-			Assert.True(uint256.ParseHex("0x" + R2L.ToString()) == R2L);
-			Assert.True(uint256.ParseHex("0x" + ZeroL.ToString()) == ZeroL);
-			Assert.True(uint256.ParseHex("0x" + OneL.ToString()) == OneL);
-			Assert.True(uint256.ParseHex("0x" + MaxL.ToString()) == MaxL);
-			Assert.True(uint256.ParseHex(R1L.ToString()) == R1L);
-			Assert.True(uint256.ParseHex("   0x" + R1L.ToString() + "   ") == R1L);
-			Assert.True(uint256.ParseHex("") == ZeroL);
-			Assert.True(R1L == uint256.ParseHex(R1ArrayHex));
+			Assert.True(uint256.Parse("0x" + R1L.ToString()) == R1L);
+			Assert.True(uint256.Parse("0x" + R2L.ToString()) == R2L);
+			Assert.True(uint256.Parse("0x" + ZeroL.ToString()) == ZeroL);
+			Assert.True(uint256.Parse("0x" + OneL.ToString()) == OneL);
+			Assert.True(uint256.Parse("0x" + MaxL.ToString()) == MaxL);
+			Assert.True(uint256.Parse(R1L.ToString()) == R1L);
+			Assert.True(uint256.Parse("   0x" + R1L.ToString() + "   ") == R1L);
+			Assert.True(uint256.Parse("") == ZeroL);
+			Assert.True(R1L == uint256.Parse(R1ArrayHex));
 			Assert.True(new uint256(R1L) == R1L);
 			Assert.True((new uint256(R1L ^ R2L) ^ R2L) == R1L);
 			Assert.True(new uint256(ZeroL) == ZeroL);
 			Assert.True(new uint256(OneL) == OneL);
 
 
-			Assert.True(uint160.ParseHex("0x" + R1S.ToString()) == R1S);
-			Assert.True(uint160.ParseHex("0x" + R2S.ToString()) == R2S);
-			Assert.True(uint160.ParseHex("0x" + ZeroS.ToString()) == ZeroS);
-			Assert.True(uint160.ParseHex("0x" + OneS.ToString()) == OneS);
-			Assert.True(uint160.ParseHex("0x" + MaxS.ToString()) == MaxS);
-			Assert.True(uint160.ParseHex(R1S.ToString()) == R1S);
-			Assert.True(uint160.ParseHex("   0x" + R1S.ToString() + "   ") == R1S);
-			Assert.True(uint160.ParseHex("") == ZeroS);
-			Assert.True(R1S == uint160.ParseHex(R1ArrayHex));
+			Assert.True(uint160.Parse("0x" + R1S.ToString()) == R1S);
+			Assert.True(uint160.Parse("0x" + R2S.ToString()) == R2S);
+			Assert.True(uint160.Parse("0x" + ZeroS.ToString()) == ZeroS);
+			Assert.True(uint160.Parse("0x" + OneS.ToString()) == OneS);
+			Assert.True(uint160.Parse("0x" + MaxS.ToString()) == MaxS);
+			Assert.True(uint160.Parse(R1S.ToString()) == R1S);
+			Assert.True(uint160.Parse("   0x" + R1S.ToString() + "   ") == R1S);
+			Assert.True(uint160.Parse("") == ZeroS);
+			Assert.True(R1S == uint160.Parse(R1ArrayHex));
 
 			Assert.True(new uint160(R1S) == R1S);
 			Assert.True((new uint160(R1S ^ R2S) ^ R2S) == R1S);
@@ -636,14 +636,14 @@ namespace NBitcoin.Tests
 			Assert.True(new uint160(OneS) == OneS);
 
 			// uint64_t constructor
-			Assert.True((R1L & uint256.ParseHex("0xffffffffffffffff")) == new uint256(R1LLow64));
+			Assert.True((R1L & uint256.Parse("0xffffffffffffffff")) == new uint256(R1LLow64));
 			Assert.True(ZeroL == new uint256(0));
 			Assert.True(OneL == new uint256(1));
-			Assert.True(uint256.ParseHex("0xffffffffffffffff") == new uint256(0xffffffffffffffffUL));
-			Assert.True((R1S & uint160.ParseHex("0xffffffffffffffff")) == new uint160(R1LLow64));
+			Assert.True(uint256.Parse("0xffffffffffffffff") == new uint256(0xffffffffffffffffUL));
+			Assert.True((R1S & uint160.Parse("0xffffffffffffffff")) == new uint160(R1LLow64));
 			Assert.True(ZeroS == new uint160(0));
 			Assert.True(OneS == new uint160(1));
-			Assert.True(uint160.ParseHex("0xffffffffffffffff") == new uint160(0xffffffffffffffffUL));
+			Assert.True(uint160.Parse("0xffffffffffffffff") == new uint160(0xffffffffffffffffUL));
 
 			// Assignment (from base_uint)
 			uint256 tmpL = ~ZeroL;

--- a/NBitcoin.Tests/uint256_tests.cs
+++ b/NBitcoin.Tests/uint256_tests.cs
@@ -271,7 +271,7 @@ namespace NBitcoin.Tests
 		public void plusMinus()
 		{
 			uint256 TmpL = 0;
-			Assert.True(R1L + R2L == new uint256(R1LplusR2L));
+			Assert.True(R1L + R2L == uint256.ParseHex(R1LplusR2L));
 			TmpL += R1L;
 			Assert.True(TmpL == R1L);
 			TmpL += R2L;
@@ -319,7 +319,7 @@ namespace NBitcoin.Tests
 
 			// 160-bit; copy-pasted
 			uint160 TmpS = 0;
-			Assert.True(R1S + R2S == new uint160(R1LplusR2L));
+			Assert.True(R1S + R2S == uint160.ParseHex(R1LplusR2L));
 			TmpS += R1S;
 			Assert.True(TmpS == R1S);
 			TmpS += R2S;
@@ -605,30 +605,30 @@ namespace NBitcoin.Tests
 			}
 			Assert.True(ZeroS == (OneS << 256));
 
-			Assert.True(new uint256("0x" + R1L.ToString()) == R1L);
-			Assert.True(new uint256("0x" + R2L.ToString()) == R2L);
-			Assert.True(new uint256("0x" + ZeroL.ToString()) == ZeroL);
-			Assert.True(new uint256("0x" + OneL.ToString()) == OneL);
-			Assert.True(new uint256("0x" + MaxL.ToString()) == MaxL);
-			Assert.True(new uint256(R1L.ToString()) == R1L);
-			Assert.True(new uint256("   0x" + R1L.ToString() + "   ") == R1L);
-			Assert.True(new uint256("") == ZeroL);
-			Assert.True(R1L == new uint256(R1ArrayHex));
+			Assert.True(uint256.ParseHex("0x" + R1L.ToString()) == R1L);
+			Assert.True(uint256.ParseHex("0x" + R2L.ToString()) == R2L);
+			Assert.True(uint256.ParseHex("0x" + ZeroL.ToString()) == ZeroL);
+			Assert.True(uint256.ParseHex("0x" + OneL.ToString()) == OneL);
+			Assert.True(uint256.ParseHex("0x" + MaxL.ToString()) == MaxL);
+			Assert.True(uint256.ParseHex(R1L.ToString()) == R1L);
+			Assert.True(uint256.ParseHex("   0x" + R1L.ToString() + "   ") == R1L);
+			Assert.True(uint256.ParseHex("") == ZeroL);
+			Assert.True(R1L == uint256.ParseHex(R1ArrayHex));
 			Assert.True(new uint256(R1L) == R1L);
 			Assert.True((new uint256(R1L ^ R2L) ^ R2L) == R1L);
 			Assert.True(new uint256(ZeroL) == ZeroL);
 			Assert.True(new uint256(OneL) == OneL);
 
 
-			Assert.True(new uint160("0x" + R1S.ToString()) == R1S);
-			Assert.True(new uint160("0x" + R2S.ToString()) == R2S);
-			Assert.True(new uint160("0x" + ZeroS.ToString()) == ZeroS);
-			Assert.True(new uint160("0x" + OneS.ToString()) == OneS);
-			Assert.True(new uint160("0x" + MaxS.ToString()) == MaxS);
-			Assert.True(new uint160(R1S.ToString()) == R1S);
-			Assert.True(new uint160("   0x" + R1S.ToString() + "   ") == R1S);
-			Assert.True(new uint160("") == ZeroS);
-			Assert.True(R1S == new uint160(R1ArrayHex));
+			Assert.True(uint160.ParseHex("0x" + R1S.ToString()) == R1S);
+			Assert.True(uint160.ParseHex("0x" + R2S.ToString()) == R2S);
+			Assert.True(uint160.ParseHex("0x" + ZeroS.ToString()) == ZeroS);
+			Assert.True(uint160.ParseHex("0x" + OneS.ToString()) == OneS);
+			Assert.True(uint160.ParseHex("0x" + MaxS.ToString()) == MaxS);
+			Assert.True(uint160.ParseHex(R1S.ToString()) == R1S);
+			Assert.True(uint160.ParseHex("   0x" + R1S.ToString() + "   ") == R1S);
+			Assert.True(uint160.ParseHex("") == ZeroS);
+			Assert.True(R1S == uint160.ParseHex(R1ArrayHex));
 
 			Assert.True(new uint160(R1S) == R1S);
 			Assert.True((new uint160(R1S ^ R2S) ^ R2S) == R1S);
@@ -636,14 +636,14 @@ namespace NBitcoin.Tests
 			Assert.True(new uint160(OneS) == OneS);
 
 			// uint64_t constructor
-			Assert.True((R1L & new uint256("0xffffffffffffffff")) == new uint256(R1LLow64));
+			Assert.True((R1L & uint256.ParseHex("0xffffffffffffffff")) == new uint256(R1LLow64));
 			Assert.True(ZeroL == new uint256(0));
 			Assert.True(OneL == new uint256(1));
-			Assert.True(new uint256("0xffffffffffffffff") == new uint256(0xffffffffffffffffUL));
-			Assert.True((R1S & new uint160("0xffffffffffffffff")) == new uint160(R1LLow64));
+			Assert.True(uint256.ParseHex("0xffffffffffffffff") == new uint256(0xffffffffffffffffUL));
+			Assert.True((R1S & uint160.ParseHex("0xffffffffffffffff")) == new uint160(R1LLow64));
 			Assert.True(ZeroS == new uint160(0));
 			Assert.True(OneS == new uint160(1));
-			Assert.True(new uint160("0xffffffffffffffff") == new uint160(0xffffffffffffffffUL));
+			Assert.True(uint160.ParseHex("0xffffffffffffffff") == new uint160(0xffffffffffffffffUL));
 
 			// Assignment (from base_uint)
 			uint256 tmpL = ~ZeroL;

--- a/NBitcoin.Tests/util_tests.cs
+++ b/NBitcoin.Tests/util_tests.cs
@@ -121,7 +121,7 @@ namespace NBitcoin.Tests
 		public void CanReadConvertTargetToDifficulty()
 		{
 			var packed = new Target(TestUtils.ParseHex("1b0404cb"));
-			var unpacked = new Target(new uint256("00000000000404CB000000000000000000000000000000000000000000000000"));
+			var unpacked = new Target(uint256.ParseHex("00000000000404CB000000000000000000000000000000000000000000000000"));
 			Assert.Equal(packed, unpacked);
 			Assert.Equal(packed, new Target(0x1b0404cb));
 
@@ -146,10 +146,10 @@ namespace NBitcoin.Tests
 			packed = new Target(419470732);
 			Assert.Equal(6978842649.592383, packed.Difficulty, "592383".Length);
 			Assert.Equal((uint)packed, (uint)419470732);
-			Assert.True(new uint256("0x0000000000000000511e193e22d2dfc02aea8037988f0c58e9834f4550e97702") < packed.ToUInt256());
+			Assert.True(uint256.ParseHex("0x0000000000000000511e193e22d2dfc02aea8037988f0c58e9834f4550e97702") < packed.ToUInt256());
 
 			//Check http://blockchain.info/block-index/394713/0000000000000000729a4a7e084c90f932d038c407a6535a51dfecdfba1c8906
-			Assert.True(new uint256("0x0000000000000000729a4a7e084c90f932d038c407a6535a51dfecdfba1c8906 ") < new Target(419470732).ToUInt256());
+			Assert.True(uint256.ParseHex("0x0000000000000000729a4a7e084c90f932d038c407a6535a51dfecdfba1c8906 ") < new Target(419470732).ToUInt256());
 
 			var genesis = Network.Main.GetGenesis();
 			Assert.True(genesis.GetHash() < genesis.Header.Bits.ToUInt256());
@@ -536,8 +536,8 @@ namespace NBitcoin.Tests
 		{
 			var jobj = JObject.Parse(File.ReadAllText("Data/blocks/Block1.json"));
 			var array = (JArray)jobj["mrkl_tree"];
-			var expected = array.OfType<JValue>().Select(v => new uint256(v.ToString())).ToList();
-			var block = Block.Parse(File.ReadAllText("Data/blocks/Block1.json"));
+			var expected = array.OfType<JValue>().Select(v => uint256.ParseHex(v.ToString())).ToList();
+			var block = Block.ParseJson(File.ReadAllText("Data/blocks/Block1.json"));
 			Assert.Equal("000000000000000040cd080615718eb68f00a0138706e7afd4068f3e08d4ca20", block.GetHash().ToString());
 			Assert.True(block.CheckMerkleRoot());
 		}

--- a/NBitcoin.Tests/util_tests.cs
+++ b/NBitcoin.Tests/util_tests.cs
@@ -121,7 +121,7 @@ namespace NBitcoin.Tests
 		public void CanReadConvertTargetToDifficulty()
 		{
 			var packed = new Target(TestUtils.ParseHex("1b0404cb"));
-			var unpacked = new Target(uint256.ParseHex("00000000000404CB000000000000000000000000000000000000000000000000"));
+			var unpacked = new Target(uint256.Parse("00000000000404CB000000000000000000000000000000000000000000000000"));
 			Assert.Equal(packed, unpacked);
 			Assert.Equal(packed, new Target(0x1b0404cb));
 
@@ -146,10 +146,10 @@ namespace NBitcoin.Tests
 			packed = new Target(419470732);
 			Assert.Equal(6978842649.592383, packed.Difficulty, "592383".Length);
 			Assert.Equal((uint)packed, (uint)419470732);
-			Assert.True(uint256.ParseHex("0x0000000000000000511e193e22d2dfc02aea8037988f0c58e9834f4550e97702") < packed.ToUInt256());
+			Assert.True(uint256.Parse("0x0000000000000000511e193e22d2dfc02aea8037988f0c58e9834f4550e97702") < packed.ToUInt256());
 
 			//Check http://blockchain.info/block-index/394713/0000000000000000729a4a7e084c90f932d038c407a6535a51dfecdfba1c8906
-			Assert.True(uint256.ParseHex("0x0000000000000000729a4a7e084c90f932d038c407a6535a51dfecdfba1c8906 ") < new Target(419470732).ToUInt256());
+			Assert.True(uint256.Parse("0x0000000000000000729a4a7e084c90f932d038c407a6535a51dfecdfba1c8906 ") < new Target(419470732).ToUInt256());
 
 			var genesis = Network.Main.GetGenesis();
 			Assert.True(genesis.GetHash() < genesis.Header.Bits.ToUInt256());
@@ -536,7 +536,7 @@ namespace NBitcoin.Tests
 		{
 			var jobj = JObject.Parse(File.ReadAllText("Data/blocks/Block1.json"));
 			var array = (JArray)jobj["mrkl_tree"];
-			var expected = array.OfType<JValue>().Select(v => uint256.ParseHex(v.ToString())).ToList();
+			var expected = array.OfType<JValue>().Select(v => uint256.Parse(v.ToString())).ToList();
 			var block = Block.ParseJson(File.ReadAllText("Data/blocks/Block1.json"));
 			Assert.Equal("000000000000000040cd080615718eb68f00a0138706e7afd4068f3e08d4ca20", block.GetHash().ToString());
 			Assert.True(block.CheckMerkleRoot());

--- a/NBitcoin/BIP32/KeyPath.cs
+++ b/NBitcoin/BIP32/KeyPath.cs
@@ -24,6 +24,8 @@ namespace NBitcoin
 		{
 			return new KeyPath(path);
 		}
+
+		[Obsolete("Use KeyPath.Parse method instead.")]
 		public KeyPath(string path)
 		{
 			_Indexes =
@@ -31,7 +33,6 @@ namespace NBitcoin
 				.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
 				.Select(ParseCore)
 				.ToArray();
-
 		}
 
 		private static uint ParseCore(string i)

--- a/NBitcoin/BIP32/KeyPath.cs
+++ b/NBitcoin/BIP32/KeyPath.cs
@@ -22,7 +22,11 @@ namespace NBitcoin
 		/// <returns></returns>
 		public static KeyPath Parse(string path)
 		{
-			return new KeyPath(path);
+			var parts = path
+				.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
+				.Select(ParseCore)
+				.ToArray();
+			return new KeyPath(parts);
 		}
 
 		[Obsolete("Use KeyPath.Parse method instead.")]

--- a/NBitcoin/Block.cs
+++ b/NBitcoin/Block.cs
@@ -395,8 +395,8 @@ namespace NBitcoin
 			blk.Header.BlockTime = Utils.UnixTimeToDateTime((uint)block["time"]);
 			blk.Header.Nonce = (uint)block["nonce"];
 			blk.Header.Version = (int)block["ver"];
-			blk.Header.HashPrevBlock = uint256.ParseHex((string)block["prev_block"]);
-			blk.Header.HashMerkleRoot = uint256.ParseHex((string)block["mrkl_root"]);
+			blk.Header.HashPrevBlock = uint256.Parse((string)block["prev_block"]);
+			blk.Header.HashMerkleRoot = uint256.Parse((string)block["mrkl_root"]);
 			foreach (var tx in txs)
 			{
 				blk.AddTransaction(formatter.Parse((JObject)tx));
@@ -404,10 +404,9 @@ namespace NBitcoin
 			return blk;
 		}
 
-		[Obsolete("Use Block.ParseJson static method instead")]
-		public static Block Parse(string json)
+		public static Block Parse(string hex)
 		{
-			return ParseJson(json);
+			return new Block(Encoders.Hex.DecodeData(hex));
 		}
 
 		public MerkleBlock Filter(params uint256[] txIds)

--- a/NBitcoin/Block.cs
+++ b/NBitcoin/Block.cs
@@ -22,6 +22,12 @@ namespace NBitcoin
 	 */
 	public class BlockHeader : IBitcoinSerializable
 	{
+		public static BlockHeader Parse(string hex)
+		{
+			return new BlockHeader(Encoders.Hex.DecodeData(hex));
+		}
+
+		[Obsolete("Use BlockHeader.Parse method instead.")]
 		public BlockHeader(string hex)
 			: this(Encoders.Hex.DecodeData(hex))
 		{
@@ -379,7 +385,7 @@ namespace NBitcoin
 			return block;
 		}
 
-		public static Block Parse(string json)
+		public static Block ParseJson(string json)
 		{
 			var formatter = new BlockExplorerFormatter();
 			var block = JObject.Parse(json);
@@ -389,13 +395,19 @@ namespace NBitcoin
 			blk.Header.BlockTime = Utils.UnixTimeToDateTime((uint)block["time"]);
 			blk.Header.Nonce = (uint)block["nonce"];
 			blk.Header.Version = (int)block["ver"];
-			blk.Header.HashPrevBlock = new uint256((string)block["prev_block"]);
-			blk.Header.HashMerkleRoot = new uint256((string)block["mrkl_root"]);
-			foreach(var tx in txs)
+			blk.Header.HashPrevBlock = uint256.ParseHex((string)block["prev_block"]);
+			blk.Header.HashMerkleRoot = uint256.ParseHex((string)block["mrkl_root"]);
+			foreach (var tx in txs)
 			{
 				blk.AddTransaction(formatter.Parse((JObject)tx));
 			}
 			return blk;
+		}
+
+		[Obsolete("Use Block.ParseJson static method instead")]
+		public static Block Parse(string json)
+		{
+			return ParseJson(json);
 		}
 
 		public MerkleBlock Filter(params uint256[] txIds)

--- a/NBitcoin/BlockrTransactionRepository.cs
+++ b/NBitcoin/BlockrTransactionRepository.cs
@@ -97,7 +97,7 @@ namespace NBitcoin
 					List<Coin> list = new List<Coin>();
 					foreach(var element in json["data"]["unspent"])
 					{
-						list.Add(new Coin(uint256.ParseHex(element["tx"].ToString()), (uint)element["n"], new Money((decimal)element["amount"], MoneyUnit.BTC), new Script(DataEncoders.Encoders.Hex.DecodeData(element["script"].ToString()))));
+						list.Add(new Coin(uint256.Parse(element["tx"].ToString()), (uint)element["n"], new Money((decimal)element["amount"], MoneyUnit.BTC), new Script(DataEncoders.Encoders.Hex.DecodeData(element["script"].ToString()))));
 					}
 					return list;
 				}

--- a/NBitcoin/BlockrTransactionRepository.cs
+++ b/NBitcoin/BlockrTransactionRepository.cs
@@ -97,7 +97,7 @@ namespace NBitcoin
 					List<Coin> list = new List<Coin>();
 					foreach(var element in json["data"]["unspent"])
 					{
-						list.Add(new Coin(new uint256(element["tx"].ToString()), (uint)element["n"], new Money((decimal)element["amount"], MoneyUnit.BTC), new Script(DataEncoders.Encoders.Hex.DecodeData(element["script"].ToString()))));
+						list.Add(new Coin(uint256.ParseHex(element["tx"].ToString()), (uint)element["n"], new Money((decimal)element["amount"], MoneyUnit.BTC), new Script(DataEncoders.Encoders.Hex.DecodeData(element["script"].ToString()))));
 					}
 					return list;
 				}

--- a/NBitcoin/ITransactionRepository.cs
+++ b/NBitcoin/ITransactionRepository.cs
@@ -14,7 +14,7 @@ namespace NBitcoin
 	{
 		public static Task<Transaction> GetAsync(this ITransactionRepository repo, string txId)
 		{
-			return repo.GetAsync(new uint256(txId));
+			return repo.GetAsync(uint256.ParseHex(txId));
 		}
 
 		public static Task PutAsync(this ITransactionRepository repo, Transaction tx)
@@ -24,7 +24,7 @@ namespace NBitcoin
 
 		public static Transaction Get(this ITransactionRepository repo, string txId)
 		{
-			return repo.Get(new uint256(txId));
+			return repo.Get(uint256.ParseHex(txId));
 		}
 
 		public static void Put(this ITransactionRepository repo, Transaction tx)

--- a/NBitcoin/ITransactionRepository.cs
+++ b/NBitcoin/ITransactionRepository.cs
@@ -14,7 +14,7 @@ namespace NBitcoin
 	{
 		public static Task<Transaction> GetAsync(this ITransactionRepository repo, string txId)
 		{
-			return repo.GetAsync(uint256.ParseHex(txId));
+			return repo.GetAsync(uint256.Parse(txId));
 		}
 
 		public static Task PutAsync(this ITransactionRepository repo, Transaction tx)
@@ -24,7 +24,7 @@ namespace NBitcoin
 
 		public static Transaction Get(this ITransactionRepository repo, string txId)
 		{
-			return repo.Get(uint256.ParseHex(txId));
+			return repo.Get(uint256.Parse(txId));
 		}
 
 		public static void Put(this ITransactionRepository repo, Transaction tx)

--- a/NBitcoin/MicroPayment/MicroChannelArguments.cs
+++ b/NBitcoin/MicroPayment/MicroChannelArguments.cs
@@ -27,17 +27,11 @@ namespace NBitcoin.MicroPayment
 	}
 	public class MicroChannelArguments
 	{
-		public static MicroChannelArguments ParseJson(string json)
-		{
-			JsonSerializerSettings settings = new JsonSerializerSettings();
-			settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
-			return JsonConvert.DeserializeObject<MicroChannelArguments>(json, settings);
-		}
-
-		[Obsolete("Use MicroChannelArguments.ParseJson method instead")]
 		public static MicroChannelArguments Parse(string json)
 		{
-			return ParseJson(json);
+			var settings = new JsonSerializerSettings();
+			settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+			return JsonConvert.DeserializeObject<MicroChannelArguments>(json, settings);
 		}
 
 		public MicroChannelArguments()

--- a/NBitcoin/MicroPayment/MicroChannelArguments.cs
+++ b/NBitcoin/MicroPayment/MicroChannelArguments.cs
@@ -27,12 +27,19 @@ namespace NBitcoin.MicroPayment
 	}
 	public class MicroChannelArguments
 	{
-		public static MicroChannelArguments Parse(string json)
+		public static MicroChannelArguments ParseJson(string json)
 		{
 			JsonSerializerSettings settings = new JsonSerializerSettings();
 			settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
 			return JsonConvert.DeserializeObject<MicroChannelArguments>(json, settings);
 		}
+
+		[Obsolete("Use MicroChannelArguments.ParseJson method instead")]
+		public static MicroChannelArguments Parse(string json)
+		{
+			return ParseJson(json);
+		}
+
 		public MicroChannelArguments()
 		{
 			Fees = Money.Coins(0.0001m);

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -144,7 +144,7 @@ namespace NBitcoin
 			hashGenesisBlock = genesis.GetHash();
 			nDefaultPort = 18444;
 			//strDataDir = "regtest";
-			assert(hashGenesisBlock == new uint256("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+			assert(hashGenesisBlock == uint256.ParseHex("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
 
 #if !PORTABLE
 			vSeeds.Clear();  // Regtest mode doesn't have any DNS seeds.
@@ -209,8 +209,8 @@ namespace NBitcoin
 			genesis.Header.Nonce = 2083236893;
 
 			hashGenesisBlock = genesis.GetHash();
-			assert(hashGenesisBlock == new uint256("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
-			assert(genesis.Header.HashMerkleRoot == new uint256("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+			assert(hashGenesisBlock == uint256.ParseHex("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
+			assert(genesis.Header.HashMerkleRoot == uint256.ParseHex("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 #if !PORTABLE
 			vSeeds.Add(new DNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be"));
 			vSeeds.Add(new DNSSeedData("bluematt.me", "dnsseed.bluematt.me"));
@@ -281,7 +281,7 @@ namespace NBitcoin
 			genesis.Header.BlockTime = Utils.UnixTimeToDateTime(1296688602);
 			genesis.Header.Nonce = 414098458;
 			hashGenesisBlock = genesis.GetHash();
-			assert(hashGenesisBlock == new uint256("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
+			assert(hashGenesisBlock == uint256.ParseHex("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
 
 #if !PORTABLE
 			vFixedSeeds.Clear();

--- a/NBitcoin/Network.cs
+++ b/NBitcoin/Network.cs
@@ -144,7 +144,7 @@ namespace NBitcoin
 			hashGenesisBlock = genesis.GetHash();
 			nDefaultPort = 18444;
 			//strDataDir = "regtest";
-			assert(hashGenesisBlock == uint256.ParseHex("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
+			assert(hashGenesisBlock == uint256.Parse("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));
 
 #if !PORTABLE
 			vSeeds.Clear();  // Regtest mode doesn't have any DNS seeds.
@@ -209,8 +209,8 @@ namespace NBitcoin
 			genesis.Header.Nonce = 2083236893;
 
 			hashGenesisBlock = genesis.GetHash();
-			assert(hashGenesisBlock == uint256.ParseHex("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
-			assert(genesis.Header.HashMerkleRoot == uint256.ParseHex("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
+			assert(hashGenesisBlock == uint256.Parse("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
+			assert(genesis.Header.HashMerkleRoot == uint256.Parse("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 #if !PORTABLE
 			vSeeds.Add(new DNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be"));
 			vSeeds.Add(new DNSSeedData("bluematt.me", "dnsseed.bluematt.me"));
@@ -281,7 +281,7 @@ namespace NBitcoin
 			genesis.Header.BlockTime = Utils.UnixTimeToDateTime(1296688602);
 			genesis.Header.Nonce = 414098458;
 			hashGenesisBlock = genesis.GetHash();
-			assert(hashGenesisBlock == uint256.ParseHex("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
+			assert(hashGenesisBlock == uint256.Parse("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
 
 #if !PORTABLE
 			vFixedSeeds.Clear();

--- a/NBitcoin/OpenAsset/IColoredTransactionRepository.cs
+++ b/NBitcoin/OpenAsset/IColoredTransactionRepository.cs
@@ -21,12 +21,12 @@ namespace NBitcoin.OpenAsset
 	{
 		public static Task<ColoredTransaction> GetAsync(this IColoredTransactionRepository repo, string txId)
 		{
-			return repo.GetAsync(uint256.ParseHex(txId));
+			return repo.GetAsync(uint256.Parse(txId));
 		}
 
 		public static ColoredTransaction Get(this IColoredTransactionRepository repo, string txId)
 		{
-			return repo.Get(uint256.ParseHex(txId));
+			return repo.Get(uint256.Parse(txId));
 		}
 
 		public static ColoredTransaction Get(this IColoredTransactionRepository repo, uint256 txId)

--- a/NBitcoin/OpenAsset/IColoredTransactionRepository.cs
+++ b/NBitcoin/OpenAsset/IColoredTransactionRepository.cs
@@ -21,12 +21,12 @@ namespace NBitcoin.OpenAsset
 	{
 		public static Task<ColoredTransaction> GetAsync(this IColoredTransactionRepository repo, string txId)
 		{
-			return repo.GetAsync(new uint256(txId));
+			return repo.GetAsync(uint256.ParseHex(txId));
 		}
 
 		public static ColoredTransaction Get(this IColoredTransactionRepository repo, string txId)
 		{
-			return repo.Get(new uint256(txId));
+			return repo.Get(uint256.ParseHex(txId));
 		}
 
 		public static ColoredTransaction Get(this IColoredTransactionRepository repo, uint256 txId)

--- a/NBitcoin/RPC/BlockExplorerFormatter.cs
+++ b/NBitcoin/RPC/BlockExplorerFormatter.cs
@@ -13,7 +13,7 @@ namespace NBitcoin.RPC
 	{
 		protected override void BuildTransaction(JObject json, Transaction tx)
 		{
-			var hash = uint256.ParseHex((string)json.GetValue("hash"));
+			var hash = uint256.Parse((string)json.GetValue("hash"));
 			tx.Version = (uint)json.GetValue("ver");
 			tx.LockTime = (uint)json.GetValue("lock_time");
 			var size = (uint)json.GetValue("size");
@@ -28,7 +28,7 @@ namespace NBitcoin.RPC
 				tx.Inputs.Add(txin);
 				var prevout = (JObject)jsonIn.GetValue("prev_out");
 
-				txin.PrevOut.Hash = uint256.ParseHex((string)prevout.GetValue("hash"));
+				txin.PrevOut.Hash = uint256.Parse((string)prevout.GetValue("hash"));
 				txin.PrevOut.N = (uint)prevout.GetValue("n");
 
 

--- a/NBitcoin/RPC/BlockExplorerFormatter.cs
+++ b/NBitcoin/RPC/BlockExplorerFormatter.cs
@@ -13,7 +13,7 @@ namespace NBitcoin.RPC
 	{
 		protected override void BuildTransaction(JObject json, Transaction tx)
 		{
-			var hash = new uint256((string)json.GetValue("hash"));
+			var hash = uint256.ParseHex((string)json.GetValue("hash"));
 			tx.Version = (uint)json.GetValue("ver");
 			tx.LockTime = (uint)json.GetValue("lock_time");
 			var size = (uint)json.GetValue("size");
@@ -24,11 +24,11 @@ namespace NBitcoin.RPC
 			for(int i = 0 ; i < vinCount ; i++)
 			{
 				var jsonIn = (JObject)vin[i];
-				var txin = new NBitcoin.TxIn();
+				var txin = new TxIn();
 				tx.Inputs.Add(txin);
 				var prevout = (JObject)jsonIn.GetValue("prev_out");
 
-				txin.PrevOut.Hash = new uint256((string)prevout.GetValue("hash"));
+				txin.PrevOut.Hash = uint256.ParseHex((string)prevout.GetValue("hash"));
 				txin.PrevOut.N = (uint)prevout.GetValue("n");
 
 

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -261,11 +261,11 @@ namespace NBitcoin.RPC
 
 		public uint256 GetBestBlockHash()
 		{
-			return new uint256((string)SendCommand("getbestblockhash").Result);
+			return uint256.ParseHex((string)SendCommand("getbestblockhash").Result);
 		}
 		public async Task<uint256> GetBestBlockHashAsync()
 		{
-			return new uint256((string)(await SendCommandAsync("getbestblockhash").ConfigureAwait(false)).Result);
+			return uint256.ParseHex((string)(await SendCommandAsync("getbestblockhash").ConfigureAwait(false)).Result);
 		}
 
 		public BitcoinSecret GetAccountSecret(string account)
@@ -455,7 +455,7 @@ namespace NBitcoin.RPC
 			header.Bits = new Target(Encoders.Hex.DecodeData((string)resp.Result["bits"]));
 			if(resp.Result["previousblockhash"] != null)
 			{
-				header.HashPrevBlock = new uint256(Encoders.Hex.DecodeData((string)resp.Result["previousblockhash"]), false);
+				header.HashPrevBlock = uint256.ParseHex((string)resp.Result["previousblockhash"], false);
 			}
 			if(resp.Result["time"] != null)
 			{
@@ -463,7 +463,7 @@ namespace NBitcoin.RPC
 			}
 			if(resp.Result["merkleroot"] != null)
 			{
-				header.HashMerkleRoot = new uint256(Encoders.Hex.DecodeData((string)resp.Result["merkleroot"]), false);
+				header.HashMerkleRoot = uint256.ParseHex((string)resp.Result["merkleroot"], false);
 			}
 			return header;
 		}
@@ -485,7 +485,7 @@ namespace NBitcoin.RPC
 			{
 				foreach(var item in tx)
 				{
-					var result = GetRawTransaction(new uint256(item.ToString()), false);
+					var result = GetRawTransaction(uint256.ParseHex(item.ToString()), false);
 					if(result != null)
 						yield return result;
 				}
@@ -501,13 +501,13 @@ namespace NBitcoin.RPC
 		public uint256 GetBlockHash(int height)
 		{
 			var resp = SendCommand("getblockhash", height);
-			return new uint256(resp.Result.ToString());
+			return uint256.ParseHex(resp.Result.ToString());
 		}
 
 		public async Task<uint256> GetBlockHashAsync(int height)
 		{
 			var resp = await SendCommandAsync("getblockhash", height).ConfigureAwait(false);
-			return new uint256(resp.Result.ToString());
+			return uint256.ParseHex(resp.Result.ToString());
 		}
 
 
@@ -524,13 +524,13 @@ namespace NBitcoin.RPC
 		{
 			var result = SendCommand("getrawmempool");
 			var array = (JArray)result.Result;
-			return array.Select(o => (string)o).Select(s => new uint256(s)).ToArray();
+			return array.Select(o => (string)o).Select(uint256.ParseHex).ToArray();
 		}
 		public async Task<uint256[]> GetRawMempoolAsync()
 		{
 			var result = await SendCommandAsync("getrawmempool").ConfigureAwait(false);
 			var array = (JArray)result.Result;
-			return array.Select(o => (string)o).Select(s => new uint256(s)).ToArray();
+			return array.Select(o => (string)o).Select(uint256.ParseHex).ToArray();
 		}
 
 		public IEnumerable<BitcoinSecret> ListSecrets()

--- a/NBitcoin/RPC/RPCClient.cs
+++ b/NBitcoin/RPC/RPCClient.cs
@@ -261,11 +261,11 @@ namespace NBitcoin.RPC
 
 		public uint256 GetBestBlockHash()
 		{
-			return uint256.ParseHex((string)SendCommand("getbestblockhash").Result);
+			return uint256.Parse((string)SendCommand("getbestblockhash").Result);
 		}
 		public async Task<uint256> GetBestBlockHashAsync()
 		{
-			return uint256.ParseHex((string)(await SendCommandAsync("getbestblockhash").ConfigureAwait(false)).Result);
+			return uint256.Parse((string)(await SendCommandAsync("getbestblockhash").ConfigureAwait(false)).Result);
 		}
 
 		public BitcoinSecret GetAccountSecret(string account)
@@ -455,7 +455,7 @@ namespace NBitcoin.RPC
 			header.Bits = new Target(Encoders.Hex.DecodeData((string)resp.Result["bits"]));
 			if(resp.Result["previousblockhash"] != null)
 			{
-				header.HashPrevBlock = uint256.ParseHex((string)resp.Result["previousblockhash"], false);
+				header.HashPrevBlock = uint256.Parse((string)resp.Result["previousblockhash"], false);
 			}
 			if(resp.Result["time"] != null)
 			{
@@ -463,7 +463,7 @@ namespace NBitcoin.RPC
 			}
 			if(resp.Result["merkleroot"] != null)
 			{
-				header.HashMerkleRoot = uint256.ParseHex((string)resp.Result["merkleroot"], false);
+				header.HashMerkleRoot = uint256.Parse((string)resp.Result["merkleroot"], false);
 			}
 			return header;
 		}
@@ -485,7 +485,7 @@ namespace NBitcoin.RPC
 			{
 				foreach(var item in tx)
 				{
-					var result = GetRawTransaction(uint256.ParseHex(item.ToString()), false);
+					var result = GetRawTransaction(uint256.Parse(item.ToString()), false);
 					if(result != null)
 						yield return result;
 				}
@@ -501,13 +501,13 @@ namespace NBitcoin.RPC
 		public uint256 GetBlockHash(int height)
 		{
 			var resp = SendCommand("getblockhash", height);
-			return uint256.ParseHex(resp.Result.ToString());
+			return uint256.Parse(resp.Result.ToString());
 		}
 
 		public async Task<uint256> GetBlockHashAsync(int height)
 		{
 			var resp = await SendCommandAsync("getblockhash", height).ConfigureAwait(false);
-			return uint256.ParseHex(resp.Result.ToString());
+			return uint256.Parse(resp.Result.ToString());
 		}
 
 
@@ -524,13 +524,13 @@ namespace NBitcoin.RPC
 		{
 			var result = SendCommand("getrawmempool");
 			var array = (JArray)result.Result;
-			return array.Select(o => (string)o).Select(uint256.ParseHex).ToArray();
+			return array.Select(o => (string)o).Select(uint256.Parse).ToArray();
 		}
 		public async Task<uint256[]> GetRawMempoolAsync()
 		{
 			var result = await SendCommandAsync("getrawmempool").ConfigureAwait(false);
 			var array = (JArray)result.Result;
-			return array.Select(o => (string)o).Select(uint256.ParseHex).ToArray();
+			return array.Select(o => (string)o).Select(uint256.Parse).ToArray();
 		}
 
 		public IEnumerable<BitcoinSecret> ListSecrets()

--- a/NBitcoin/RPC/RawFormatter.cs
+++ b/NBitcoin/RPC/RawFormatter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.IO;
 
@@ -15,6 +16,13 @@ namespace NBitcoin.RPC
 			get;
 			set;
 		}
+		public Transaction ParseJson(string str)
+		{
+			JObject obj = JObject.Parse(str);
+			return Parse(obj);
+		}
+
+		[Obsolete("Use RawFormatter.ParseJson method instead")]
 		public Transaction Parse(string str)
 		{
 			JObject obj = JObject.Parse(str);

--- a/NBitcoin/RPC/SatoshiFormatter.cs
+++ b/NBitcoin/RPC/SatoshiFormatter.cs
@@ -14,7 +14,7 @@ namespace NBitcoin.RPC
 	{
 		protected override void BuildTransaction(JObject json, Transaction tx)
 		{
-			var txid = uint256.ParseHex((string)json.GetValue("txid"));
+			var txid = uint256.Parse((string)json.GetValue("txid"));
 			tx.Version = (uint)json.GetValue("version");
 			tx.LockTime = (uint)json.GetValue("locktime");
 
@@ -29,7 +29,7 @@ namespace NBitcoin.RPC
 				if(script != null)
 				{
 					txin.ScriptSig = new Script(Encoders.Hex.DecodeData((string)script.GetValue("hex")));
-					txin.PrevOut.Hash = uint256.ParseHex((string)jsonIn.GetValue("txid"));
+					txin.PrevOut.Hash = uint256.Parse((string)jsonIn.GetValue("txid"));
 					txin.PrevOut.N = (uint)jsonIn.GetValue("vout");
 				}
 				else

--- a/NBitcoin/RPC/SatoshiFormatter.cs
+++ b/NBitcoin/RPC/SatoshiFormatter.cs
@@ -14,7 +14,7 @@ namespace NBitcoin.RPC
 	{
 		protected override void BuildTransaction(JObject json, Transaction tx)
 		{
-			var txid = new uint256((string)json.GetValue("txid"));
+			var txid = uint256.ParseHex((string)json.GetValue("txid"));
 			tx.Version = (uint)json.GetValue("version");
 			tx.LockTime = (uint)json.GetValue("locktime");
 
@@ -22,14 +22,14 @@ namespace NBitcoin.RPC
 			for(int i = 0 ; i < vin.Count ; i++)
 			{
 				var jsonIn = (JObject)vin[i];
-				var txin = new NBitcoin.TxIn();
+				var txin = new TxIn();
 				tx.Inputs.Add(txin);
 
 				var script = (JObject)jsonIn.GetValue("scriptSig");
 				if(script != null)
 				{
 					txin.ScriptSig = new Script(Encoders.Hex.DecodeData((string)script.GetValue("hex")));
-					txin.PrevOut.Hash = new uint256((string)jsonIn.GetValue("txid"));
+					txin.PrevOut.Hash = uint256.ParseHex((string)jsonIn.GetValue("txid"));
 					txin.PrevOut.N = (uint)jsonIn.GetValue("vout");
 				}
 				else
@@ -46,7 +46,7 @@ namespace NBitcoin.RPC
 			for(int i = 0 ; i < vout.Count ; i++)
 			{
 				var jsonOut = (JObject)vout[i];
-				var txout = new NBitcoin.TxOut();
+				var txout = new TxOut();
 				tx.Outputs.Add(txout);
 
 				var btc = (decimal)jsonOut.GetValue("value");

--- a/NBitcoin/RPC/UnspentCoin.cs
+++ b/NBitcoin/RPC/UnspentCoin.cs
@@ -12,7 +12,7 @@ namespace NBitcoin.RPC
 	{
 		public UnspentCoin(JObject unspent)
 		{
-			OutPoint = new OutPoint(new uint256((string)unspent["txid"]), (uint)unspent["vout"]);
+			OutPoint = new OutPoint(uint256.ParseHex((string)unspent["txid"]), (uint)unspent["vout"]);
 			Address = Network.CreateFromBase58Data<BitcoinAddress>((string)unspent["address"]);
 			Account = (string)unspent["account"];
 			ScriptPubKey = new Script(Encoders.Hex.DecodeData((string)unspent["scriptPubKey"]));

--- a/NBitcoin/RPC/UnspentCoin.cs
+++ b/NBitcoin/RPC/UnspentCoin.cs
@@ -12,7 +12,7 @@ namespace NBitcoin.RPC
 	{
 		public UnspentCoin(JObject unspent)
 		{
-			OutPoint = new OutPoint(uint256.ParseHex((string)unspent["txid"]), (uint)unspent["vout"]);
+			OutPoint = new OutPoint(uint256.Parse((string)unspent["txid"]), (uint)unspent["vout"]);
 			Address = Network.CreateFromBase58Data<BitcoinAddress>((string)unspent["address"]);
 			Account = (string)unspent["account"];
 			ScriptPubKey = new Script(Encoders.Hex.DecodeData((string)unspent["scriptPubKey"]));

--- a/NBitcoin/SPV/Tracker.cs
+++ b/NBitcoin/SPV/Tracker.cs
@@ -205,12 +205,12 @@ namespace NBitcoin.SPV
 				if(blockId != null)
 				{
 					op.Height = (int)(long)obj["Height"];
-					op.BlockId = new uint256(blockId);
+					op.BlockId = uint256.ParseHex(blockId);
 					op.Proof = new MerkleBlock();
 					op.Proof.FromBytes(Encoders.Hex.DecodeData((string)obj["Proof"]));
 				}
-				op.AddedDate = ((JValue)obj["AddedDate"]).Value<DateTimeOffset>();
-				op.UnconfirmedSeen = ((JValue)obj["UnconfirmedSeen"]).Value<DateTimeOffset>();
+				op.AddedDate = obj["AddedDate"].Value<DateTimeOffset>();
+				op.UnconfirmedSeen = obj["UnconfirmedSeen"].Value<DateTimeOffset>();
 				op.Transaction = new Transaction();
 				op.Transaction.FromBytes(Encoders.Hex.DecodeData((string)obj["Transaction"]));
 				var coins = obj["ReceivedCoins"] as JArray;

--- a/NBitcoin/SPV/Tracker.cs
+++ b/NBitcoin/SPV/Tracker.cs
@@ -205,7 +205,7 @@ namespace NBitcoin.SPV
 				if(blockId != null)
 				{
 					op.Height = (int)(long)obj["Height"];
-					op.BlockId = uint256.ParseHex(blockId);
+					op.BlockId = uint256.Parse(blockId);
 					op.Proof = new MerkleBlock();
 					op.Proof.FromBytes(Encoders.Hex.DecodeData((string)obj["Proof"]));
 				}

--- a/NBitcoin/SPV/Wallet.cs
+++ b/NBitcoin/SPV/Wallet.cs
@@ -87,7 +87,7 @@ namespace NBitcoin.SPV
 		{
 			WalletCreation creation = new WalletCreation();
 			creation.SignatureRequired = (int)(long)obj["SignatureRequired"];
-			creation.DerivationPath = new KeyPath((string)obj["DerivationPath"]);
+			creation.DerivationPath = KeyPath.Parse((string)obj["DerivationPath"]);
 			creation.UseP2SH = (bool)obj["UseP2SH"];
 			var array = (JArray)obj["RootKeys"];
 			var keys = array.Select(i => new BitcoinExtPubKey((string)i)).ToArray();
@@ -513,7 +513,7 @@ namespace NBitcoin.SPV
 			foreach(var known in knownScripts.OfType<JObject>())
 			{
 				Script script = Script.FromBytesUnsafe(Encoders.Hex.DecodeData((string)known["ScriptPubKey"]));
-				KeyPath keypath = new KeyPath((string)known["KeyPath"]);
+				KeyPath keypath = KeyPath.Parse((string)known["KeyPath"]);
 				_KnownScripts.Add(script, keypath);
 			}
 		}

--- a/NBitcoin/Transaction.cs
+++ b/NBitcoin/Transaction.cs
@@ -975,7 +975,7 @@ namespace NBitcoin
 
 		public static Transaction Parse(string tx, RawFormat format, Network network = null)
 		{
-			return GetFormatter(format, network).Parse(tx);
+			return GetFormatter(format, network).ParseJson(tx);
 		}
 
 		public string ToHex()

--- a/NBitcoin/UInt256.tt
+++ b/NBitcoin/UInt256.tt
@@ -28,6 +28,16 @@ namespace NBitcoin
 				pn[i] = b.pn[i];
 		}
 
+		public static uint<#= t #> ParseHex(string hex)
+		{
+			return new uint<#= t #>(hex);
+		}
+
+		public static uint<#= t #> ParseHex(string hex, bool lendian)
+		{
+			return new uint<#= t #>(Encoder.DecodeData(hex), lendian);
+		}
+
 		private static readonly HexEncoder Encoder = new HexEncoder();
 		private const int WIDTH = <#= t #> / 32;
 		private const int WIDTH_BYTE = <#= t #> / 8;
@@ -86,6 +96,7 @@ namespace NBitcoin
 			SetBytes(vch);
 		}
 
+		[Obsolete("Use uint<#= t #>.Parse method instead.")]
 		public uint<#= t #>(string str)
 		{
 			SetHex(str);

--- a/NBitcoin/UInt256.tt
+++ b/NBitcoin/UInt256.tt
@@ -28,12 +28,12 @@ namespace NBitcoin
 				pn[i] = b.pn[i];
 		}
 
-		public static uint<#= t #> ParseHex(string hex)
+		public static uint<#= t #> Parse(string hex)
 		{
 			return new uint<#= t #>(hex);
 		}
 
-		public static uint<#= t #> ParseHex(string hex, bool lendian)
+		public static uint<#= t #> Parse(string hex, bool lendian)
 		{
 			return new uint<#= t #>(Encoder.DecodeData(hex), lendian);
 		}

--- a/NBitcoin/UInt256.tt
+++ b/NBitcoin/UInt256.tt
@@ -30,12 +30,14 @@ namespace NBitcoin
 
 		public static uint<#= t #> Parse(string hex)
 		{
-			return new uint<#= t #>(hex);
+			return uint<#= t #>.Parse(hex, true);
 		}
 
 		public static uint<#= t #> Parse(string hex, bool lendian)
 		{
-			return new uint<#= t #>(Encoder.DecodeData(hex), lendian);
+			var ret = new uint<#= t #>();
+			ret.SetHex(hex, lendian);
+			return ret;
 		}
 
 		private static readonly HexEncoder Encoder = new HexEncoder();
@@ -43,7 +45,7 @@ namespace NBitcoin
 		private const int WIDTH_BYTE = <#= t #> / 8;
 		private UInt32[] pn = new UInt32[WIDTH];
 
-		internal void SetHex(string str)
+		internal void SetHex(string str, bool lendian = true)
 		{
 			Array.Clear(pn, 0, pn.Length);
 			str = str.Trim();
@@ -51,7 +53,10 @@ namespace NBitcoin
 			if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
 				str = str.Substring(2);
 
-			SetBytes(Encoder.DecodeData(str).Reverse().ToArray());
+			var bytes = Encoder.DecodeData(str);
+			if(lendian)
+				bytes = bytes.Reverse().ToArray();
+			SetBytes(bytes);
 		}
 
 		public byte GetByte(int index)

--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -23,12 +23,14 @@ namespace NBitcoin
 
 		public static uint256 Parse(string hex)
 		{
-			return new uint256(hex);
+			return uint256.Parse(hex, true);
 		}
 
 		public static uint256 Parse(string hex, bool lendian)
 		{
-			return new uint256(Encoder.DecodeData(hex), lendian);
+			var ret = new uint256();
+			ret.SetHex(hex, lendian);
+			return ret;
 		}
 
 		private static readonly HexEncoder Encoder = new HexEncoder();
@@ -36,7 +38,7 @@ namespace NBitcoin
 		private const int WIDTH_BYTE = 256 / 8;
 		private UInt32[] pn = new UInt32[WIDTH];
 
-		internal void SetHex(string str)
+		internal void SetHex(string str, bool lendian = true)
 		{
 			Array.Clear(pn, 0, pn.Length);
 			str = str.Trim();
@@ -44,7 +46,10 @@ namespace NBitcoin
 			if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
 				str = str.Substring(2);
 
-			SetBytes(Encoder.DecodeData(str).Reverse().ToArray());
+			var bytes = Encoder.DecodeData(str);
+			if(lendian)
+				bytes = bytes.Reverse().ToArray();
+			SetBytes(bytes);
 		}
 
 		public byte GetByte(int index)
@@ -380,12 +385,14 @@ namespace NBitcoin
 
 		public static uint160 Parse(string hex)
 		{
-			return new uint160(hex);
+			return uint160.Parse(hex, true);
 		}
 
 		public static uint160 Parse(string hex, bool lendian)
 		{
-			return new uint160(Encoder.DecodeData(hex), lendian);
+			var ret = new uint160();
+			ret.SetHex(hex, lendian);
+			return ret;
 		}
 
 		private static readonly HexEncoder Encoder = new HexEncoder();
@@ -393,7 +400,7 @@ namespace NBitcoin
 		private const int WIDTH_BYTE = 160 / 8;
 		private UInt32[] pn = new UInt32[WIDTH];
 
-		internal void SetHex(string str)
+		internal void SetHex(string str, bool lendian = true)
 		{
 			Array.Clear(pn, 0, pn.Length);
 			str = str.Trim();
@@ -401,7 +408,10 @@ namespace NBitcoin
 			if (str.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
 				str = str.Substring(2);
 
-			SetBytes(Encoder.DecodeData(str).Reverse().ToArray());
+			var bytes = Encoder.DecodeData(str);
+			if(lendian)
+				bytes = bytes.Reverse().ToArray();
+			SetBytes(bytes);
 		}
 
 		public byte GetByte(int index)

--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -21,12 +21,12 @@ namespace NBitcoin
 				pn[i] = b.pn[i];
 		}
 
-		public static uint256 ParseHex(string hex)
+		public static uint256 Parse(string hex)
 		{
 			return new uint256(hex);
 		}
 
-		public static uint256 ParseHex(string hex, bool lendian)
+		public static uint256 Parse(string hex, bool lendian)
 		{
 			return new uint256(Encoder.DecodeData(hex), lendian);
 		}
@@ -378,12 +378,12 @@ namespace NBitcoin
 				pn[i] = b.pn[i];
 		}
 
-		public static uint160 ParseHex(string hex)
+		public static uint160 Parse(string hex)
 		{
 			return new uint160(hex);
 		}
 
-		public static uint160 ParseHex(string hex, bool lendian)
+		public static uint160 Parse(string hex, bool lendian)
 		{
 			return new uint160(Encoder.DecodeData(hex), lendian);
 		}

--- a/NBitcoin/UInt2561.cs
+++ b/NBitcoin/UInt2561.cs
@@ -21,6 +21,16 @@ namespace NBitcoin
 				pn[i] = b.pn[i];
 		}
 
+		public static uint256 ParseHex(string hex)
+		{
+			return new uint256(hex);
+		}
+
+		public static uint256 ParseHex(string hex, bool lendian)
+		{
+			return new uint256(Encoder.DecodeData(hex), lendian);
+		}
+
 		private static readonly HexEncoder Encoder = new HexEncoder();
 		private const int WIDTH = 256 / 32;
 		private const int WIDTH_BYTE = 256 / 8;
@@ -79,6 +89,7 @@ namespace NBitcoin
 			SetBytes(vch);
 		}
 
+		[Obsolete("Use uint256.Parse method instead.")]
 		public uint256(string str)
 		{
 			SetHex(str);
@@ -367,6 +378,16 @@ namespace NBitcoin
 				pn[i] = b.pn[i];
 		}
 
+		public static uint160 ParseHex(string hex)
+		{
+			return new uint160(hex);
+		}
+
+		public static uint160 ParseHex(string hex, bool lendian)
+		{
+			return new uint160(Encoder.DecodeData(hex), lendian);
+		}
+
 		private static readonly HexEncoder Encoder = new HexEncoder();
 		private const int WIDTH = 160 / 32;
 		private const int WIDTH_BYTE = 160 / 8;
@@ -425,6 +446,7 @@ namespace NBitcoin
 			SetBytes(vch);
 		}
 
+		[Obsolete("Use uint160.Parse method instead.")]
 		public uint160(string str)
 		{
 			SetHex(str);


### PR DESCRIPTION
When we have to create an object instance from its string representation, the .NET Framework is very consistent, it provides a Parse static method. NBitcoin provides Parse methods in many cases and also contructors with string parameters in other clases.

```UInt32.Parse("12")``` is the .NET Fx convention. ```new UInt32("12")``` is not.  

Now, in some cases we shouldn't call *Parse* to those methods that receive a string as parameter because that could be confusing. In code:

```UInt32.Parse("12345")   // this is ok```
```UInt256.Parse("12345") // fails even when 12345 is a valid uint256 value (base10)```

That's why in some cases the Parse method should be called differently. In this case (uint256) it should be called **ParseHex**.

```UInt256.ParseHex("12345") // now it is clear that 12345 is not a valid hexadecimal value```

Something similar happens with other Parse methods that receive strings but is not clear what the expected string representation is. For example **Block.Parse** which expects a json representation and not a hex representation. Look:

```BlockHeader.Parse() // this method expects a hex representation```
```Block.Parse() // but this method expects a json. it´s not consistent.```
 
In this cases it should be called **ParseJson**.

This PR doesn't break the existing NBitcoin contracts but uses ```ObsoleteAttribute``` in order to let the developer know that the used method could be remove in the future.

