### PR TITLE
RPC GetPeersInfo

### DIFF
--- a/NBitcoin.Tests/RPCClientTests.cs
+++ b/NBitcoin.Tests/RPCClientTests.cs
@@ -155,6 +155,14 @@ namespace NBitcoin.Tests
 			AssertJsonEquals(tx.ToString(RawFormat.Satoshi), tx2.ToString(RawFormat.Satoshi));
 		}
 
+		[Fact]
+		[Trait("RPCClient", "RPCClient")]
+		public void CanGetPeersInfo()
+		{
+			var rpc = CreateRPCClient();
+			var peers = rpc.GetPeersInfo();
+			Assert.NotEmpty(peers);
+		}
 
 		private void AssertJsonEquals(string json1, string json2)
 		{


### PR DESCRIPTION
This PR contains the ```RPC GetPeerInfo``` method. It is necessary to improve the UT and decide the best strategy for dealing with optional fields (Nullables?). Anyway, it works well.